### PR TITLE
Genome downloader

### DIFF
--- a/bin/reference_data.py
+++ b/bin/reference_data.py
@@ -8,7 +8,6 @@ from egcg_core.config import cfg
 from egcg_core.app_logging import logging_default as log_cfg
 from config import load_config
 
-load_config()
 log_cfg.add_stdout_handler()
 app_logger = log_cfg.get_logger('genome_downloader')
 
@@ -119,6 +118,7 @@ def get_dbsnp(taxid):
 
 
 def main(argv=None):
+    load_config()
     a = argparse.ArgumentParser()
     a.add_argument('action', choices=('list', 'info'))
     a.add_argument('type', choices=('genome', 'dbsnp'))

--- a/bin/reference_data.py
+++ b/bin/reference_data.py
@@ -1,21 +1,31 @@
+import os
 import requests
 import argparse
 import ftplib
+import yaml
+from datetime import datetime
+from egcg_core.config import cfg
 from egcg_core.app_logging import logging_default as log_cfg
+from config import load_config
 
+load_config()
 log_cfg.add_stdout_handler()
 app_logger = log_cfg.get_logger('genome_downloader')
+
+
+def _now():
+    return datetime.now().strftime('%d/%m/%Y %H:%M:%S')
 
 
 def _query_ncbi(eutil, db, **query_args):
     url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/' + eutil + '.fcgi'
     params = {'db': db, 'retmode': 'JSON', 'version': '2.0'}
     params.update(query_args)
-    return requests.get(url, params)
+    return requests.get(url, params).json()
 
 
 def list_ids(db, search_term, retmax=20):
-    ids = _query_ncbi('esearch', db, term=search_term, retmax=retmax).json()['esearchresult']
+    ids = _query_ncbi('esearch', db, term=search_term, retmax=retmax)['esearchresult']
     if int(ids['count']) > retmax:
         app_logger.warning('More than %s results found - try a higher retmax, or narrow the search term', retmax)
 
@@ -24,21 +34,67 @@ def list_ids(db, search_term, retmax=20):
 
 
 def list_reference_genomes(search_term):
-    genome_ids = list_ids('assembly', search_term)
-
-    genome_summaries = _query_ncbi('esummary', 'assembly', id=','.join(genome_ids)).json()['result']
+    genome_ids = [str(i) for i in list_ids('assembly', search_term)]
+    genome_summaries = _query_ncbi('esummary', 'assembly', id=','.join(genome_ids))['result']
     genome_summaries.pop('uids')
     for v in genome_summaries.values():
         print(
-            '{name}, species {species} ({taxid}), released {date}, ftp={ftp_path}'.format(
-                name=v['assemblyname'], species=v['speciesname'], taxid=v['speciestaxid'],
+            '{id} {name}, species {species} ({taxid}), released {date}, ftp={ftp_path}'.format(
+                id=v['uid'], name=v['assemblyname'], species=v['speciesname'], taxid=v['speciestaxid'],
                 date=v['seqreleasedate'], ftp_path=v.get('ftppath_genbank') or '(no ftp available)'
             )
         )
 
 
-def summarise_dbsnp(taxid):
-    ftp = ftplib.FTP('ftp.ncbi.nlm.nih.gov')
+def record_reference_data(species, assembly, metadata):
+    """
+    Write metadata to a file in reference_data/species/metadata.yaml.
+    :param str species:
+    :param str assembly: The genome assembly to write to, or 'dbsnp'
+    :param dict metadata:
+    """
+    md_dir = os.path.join(cfg['genome_downloader']['base_dir'], species.replace(' ', '_'))
+    os.makedirs(md_dir, exist_ok=True)
+    md_file = os.path.join(md_dir, 'metadata.yaml')
+
+    content = {}
+    if os.path.isfile(md_file):
+        with open(md_file, 'r') as f:
+            content = yaml.safe_load(f)
+
+    if assembly in content:
+        app_logger.warning('%s already in metadata file. Remove this to re-run', assembly)
+        return 0
+
+    now = _now()
+    metadata['date_downloaded'] = now
+    content[assembly] = metadata
+
+    with open(md_file, 'w') as f:
+        f.write('# metadata for %s, last modified %s\n' % (species, now))
+        yaml.safe_dump(content, f, indent=4, default_flow_style=False)
+
+
+def get_reference_genome(uid):
+    data = _query_ncbi('esummary', 'assembly', id=uid)['result'][uid]
+    app_logger.info('Download Fasta files from %s, merge and index with bwa and bowtie', data['ftppath_genbank'])
+
+    keys = ('organism', 'assemblyname', 'seqreleasedate', 'speciestaxid', 'uid', 'ftppath_genbank')
+    record_reference_data(
+        data['speciesname'],
+        data['assemblyname'],
+        {k: data[k] for k in keys}
+    )
+
+
+def list_taxids(search_term):
+    ids = list_ids('taxonomy', search_term)
+    app_logger.info('Found %s taxids for search term %s: %s', len(ids), search_term, ids)
+
+
+def get_dbsnp(taxid):
+    host = 'ftp.ncbi.nlm.nih.gov'
+    ftp = ftplib.FTP(host)
     ftp.login()
     wd = 'snp/organisms/'
 
@@ -50,35 +106,37 @@ def summarise_dbsnp(taxid):
             break
 
     ls = dict(ftp.mlsd(wd + dname))
-    if 'VCF' in ls:
-        vcf_path = 'ftp://' + ftp.host + '/' + wd + dname + '/VCF'
-        app_logger.info('Found dbsnp vcfs for %s at %s', dname, vcf_path)
-    else:
-        app_logger.warning('No vcfs found for %s', dname)
-
     ftp.quit()
+    if 'VCF' not in ls:
+        app_logger.warning('No vcfs found for %s', dname)
+        return 1
+
+    vcf_path = 'ftp://' + host + '/' + wd + dname + '/VCF'
+    app_logger.info('Found dbsnp vcfs for %s at %s', dname, vcf_path)
+
+    esummary = _query_ncbi('esummary', 'taxonomy', id=taxid)['result'][taxid]
+    record_reference_data(esummary['scientificname'], 'dbsnp', {'ftp': vcf_path, 'taxid': taxid})
 
 
 def main(argv=None):
     a = argparse.ArgumentParser()
-    a.add_argument('action', choices=('info',))
+    a.add_argument('action', choices=('list', 'info'))
     a.add_argument('type', choices=('genome', 'dbsnp'))
-    a.add_argument('--search_term')
+    a.add_argument('--search_term', required=True)
 
     args = a.parse_args(argv)
 
-    if args.action == 'info' and args.type == 'genome':
+    if args.action == 'list' and args.type == 'genome':
         list_reference_genomes(args.search_term)
 
+    elif args.action == 'list' and args.type == 'dbsnp':
+        list_taxids(args.search_term)
+
+    elif args.action == 'info' and args.type == 'genome':
+        get_reference_genome(args.search_term)
+
     elif args.action == 'info' and args.type == 'dbsnp':
-        ids = list_ids('taxonomy', args.search_term)
-        if len(ids) != 1:
-            app_logger.error('%s taxids found for %s - try narrowing the search term', len(ids), args.search_term)
-            return 1
+        get_dbsnp(args.search_term)
 
-        summarise_dbsnp(ids[0])
-
-
-if __name__ == '__main__':
-    main(['info', 'genome', '--search_term', 'Bos taurus'])
-    main(['info', 'dbsnp', '--search_term', 'Bos taurus'])
+    else:
+        return 1

--- a/bin/reference_data.py
+++ b/bin/reference_data.py
@@ -1,0 +1,84 @@
+import requests
+import argparse
+import ftplib
+from egcg_core.app_logging import logging_default as log_cfg
+
+log_cfg.add_stdout_handler()
+app_logger = log_cfg.get_logger('genome_downloader')
+
+
+def _query_ncbi(eutil, db, **query_args):
+    url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/' + eutil + '.fcgi'
+    params = {'db': db, 'retmode': 'JSON', 'version': '2.0'}
+    params.update(query_args)
+    return requests.get(url, params)
+
+
+def list_ids(db, search_term, retmax=20):
+    ids = _query_ncbi('esearch', db, term=search_term, retmax=retmax).json()['esearchresult']
+    if int(ids['count']) > retmax:
+        app_logger.warning('More than %s results found - try a higher retmax, or narrow the search term', retmax)
+
+    app_logger.info('Found %s ids in %s database for %s', ids['count'], db, search_term)
+    return ids['idlist']
+
+
+def list_reference_genomes(search_term):
+    genome_ids = list_ids('assembly', search_term)
+
+    genome_summaries = _query_ncbi('esummary', 'assembly', id=','.join(genome_ids)).json()['result']
+    genome_summaries.pop('uids')
+    for v in genome_summaries.values():
+        print(
+            '{name}, species {species} ({taxid}), released {date}, ftp={ftp_path}'.format(
+                name=v['assemblyname'], species=v['speciesname'], taxid=v['speciestaxid'],
+                date=v['seqreleasedate'], ftp_path=v.get('ftppath_genbank') or '(no ftp available)'
+            )
+        )
+
+
+def summarise_dbsnp(taxid):
+    ftp = ftplib.FTP('ftp.ncbi.nlm.nih.gov')
+    ftp.login()
+    wd = 'snp/organisms/'
+
+    dname = None
+    dbsnp_entries = dict(ftp.mlsd(wd))
+    for d in dbsnp_entries:
+        if d.endswith(taxid):
+            dname = d
+            break
+
+    ls = dict(ftp.mlsd(wd + dname))
+    if 'VCF' in ls:
+        vcf_path = 'ftp://' + ftp.host + '/' + wd + dname + '/VCF'
+        app_logger.info('Found dbsnp vcfs for %s at %s', dname, vcf_path)
+    else:
+        app_logger.warning('No vcfs found for %s', dname)
+
+    ftp.quit()
+
+
+def main(argv=None):
+    a = argparse.ArgumentParser()
+    a.add_argument('action', choices=('info',))
+    a.add_argument('type', choices=('genome', 'dbsnp'))
+    a.add_argument('--search_term')
+
+    args = a.parse_args(argv)
+
+    if args.action == 'info' and args.type == 'genome':
+        list_reference_genomes(args.search_term)
+
+    elif args.action == 'info' and args.type == 'dbsnp':
+        ids = list_ids('taxonomy', args.search_term)
+        if len(ids) != 1:
+            app_logger.error('%s taxids found for %s - try narrowing the search term', len(ids), args.search_term)
+            return 1
+
+        summarise_dbsnp(ids[0])
+
+
+if __name__ == '__main__':
+    main(['info', 'genome', '--search_term', 'Bos taurus'])
+    main(['info', 'dbsnp', '--search_term', 'Bos taurus'])

--- a/etc/example_project_management.yaml
+++ b/etc/example_project_management.yaml
@@ -38,3 +38,6 @@ default:
     sample:
       delivery_source: tests/assets/project_report/source
       delivery_dest: tests/assets/project_report/dest
+
+    genome_downloader:
+        base_dir: path/to/reference_data

--- a/tests/test_data_deletion/test_delivered_deletion.py
+++ b/tests/test_data_deletion/test_delivered_deletion.py
@@ -154,6 +154,7 @@ class TestDeliveredDataDeleter(TestDeleter):
     def test_deletable_samples(self):
         pass
 
+    @patch.object(ProcessedSample, 'release_date', new='sometime')
     @patch.object(ProcessedSample, 'size_of_files', new=1000000000)
     @patch.object(ProcessedSample, 'files_to_purge', new=['file1', 'file2'])
     @patch.object(ProcessedSample, 'files_to_remove_from_lustre', new=[])

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,0 +1,93 @@
+from bin import reference_data
+from unittest.mock import Mock, MagicMock, patch
+from tests import TestProjectManagement
+reference_data.cfg.load_config_file(TestProjectManagement.etc_config)
+
+ppath = 'bin.reference_data.'
+
+
+@patch(ppath + 'requests.get')
+def test_query_ncbi(mocked_get):
+    reference_data._query_ncbi('an_eutil', 'a_db', this='that', other='another')
+    mocked_get.assert_called_with(
+        'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/an_eutil.fcgi',
+        {'db': 'a_db', 'retmode': 'JSON', 'version': '2.0', 'this': 'that', 'other': 'another'}
+    )
+
+
+@patch(ppath + '_query_ncbi', return_value={'esearchresult': {'count': 2, 'idlist': [1337]}})
+def test_list_ids(mocked_query):
+    assert reference_data.list_ids('a_db', 'Thingius thingy') == [1337]
+    mocked_query.assert_called_with('esearch', 'a_db', term='Thingius thingy', retmax=20)
+
+
+fake_esummary = {
+    'result': {
+        'uids': ['11337', '11338'],
+        '11337': {'uid': '11337', 'assemblyname': 'tThi_1.337', 'speciesname': 'Thingius thingy',
+                  'organism': 'Thingius thingy (some kind of flappy swimmy thing)', 'speciestaxid': '1337',
+                  'seqreleasedate': 'then', 'ftppath_genbank': 'an_ftp_site/tThi_1.338/'},
+        '11338': {'uid': '11338', 'assemblyname': 'tThi_1.338', 'speciesname': 'Thingius thingy',
+                  'speciestaxid': '1337', 'seqreleasedate': 'now', 'ftppath_genbank': None}
+    }
+}
+
+
+@patch(ppath + 'list_ids', return_value=['11337', '11338'])
+@patch(ppath + '_query_ncbi', return_value=fake_esummary)
+@patch('builtins.print')
+def test_list_reference_genomes(mocked_print, mocked_query, mocked_list_ids):
+    reference_data.list_reference_genomes('Thingius thingy')
+    mocked_list_ids.assert_called_with('assembly', 'Thingius thingy')
+    mocked_query.assert_called_with('esummary', 'assembly', id='11337,11338')
+    for s in ('11337 tThi_1.337, species Thingius thingy (1337), released then, ftp=an_ftp_site/tThi_1.338/',
+              '11338 tThi_1.338, species Thingius thingy (1337), released now, ftp=(no ftp available)'):
+        mocked_print.assert_any_call(s)
+
+
+@patch(ppath + 'yaml')
+@patch('builtins.open', return_value=MagicMock())
+def test_record_reference_data(mocked_open, mocked_yaml):
+    with patch(ppath + '_now', return_value='now'), patch(ppath + 'os.makedirs'):
+        reference_data.record_reference_data('Thingius thingy', 'tThi_1.337', {'some': 'metadata'})
+
+    mocked_open.assert_called_with('path/to/reference_data/Thingius_thingy/metadata.yaml', 'w')
+    mocked_file = mocked_open().__enter__()
+    mocked_file.write.assert_any_call('# metadata for Thingius thingy, last modified now\n')
+    mocked_yaml.safe_dump.assert_called_with(
+        {'tThi_1.337': {'date_downloaded': 'now', 'some': 'metadata'}},
+        mocked_file, indent=4, default_flow_style=False
+    )
+
+
+@patch(ppath + '_query_ncbi', return_value=fake_esummary)
+@patch(ppath + 'record_reference_data')
+def test_get_reference_genome(mocked_record, mocked_query):
+    reference_data.get_reference_genome('11337')
+    mocked_query.assert_called_with('esummary', 'assembly', id='11337')
+    mocked_record.assert_called_with(
+        'Thingius thingy',
+        'tThi_1.337',
+        {'uid': '11337', 'assemblyname': 'tThi_1.337',
+         'organism': 'Thingius thingy (some kind of flappy swimmy thing)', 'speciestaxid': '1337',
+            'seqreleasedate': 'then', 'ftppath_genbank': 'an_ftp_site/tThi_1.338/'}
+    )
+
+
+fake_mlsds = [
+    {'thing_11337': None},
+    {'VCF': None, '.': None, '..': None}
+]
+
+
+@patch(ppath + 'record_reference_data')
+@patch('ftplib.FTP', return_value=Mock(mlsd=Mock(side_effect=fake_mlsds)))
+def test_get_dbsnp(mocked_ftp, mocked_record):
+    with patch(ppath + '_query_ncbi', return_value={'result': {'11337': {'scientificname': 'Thingius thingy'}}}):
+        reference_data.get_dbsnp('11337')
+    mocked_ftp().mlsd.assert_any_call('snp/organisms/thing_11337')
+    mocked_record.assert_called_with(
+        'Thingius thingy',
+        'dbsnp',
+        {'ftp': 'ftp://ftp.ncbi.nlm.nih.gov/snp/organisms/thing_11337/VCF', 'taxid': '11337'}
+    )


### PR DESCRIPTION
This adds a tool for aiding the downloading of genomic reference data.

- `list genome <search_term>` lists NCBI genome assemblies, including assembly name, taxid, release date and FTP path
- `info genome <uid>` writes this information to a Yaml file for the given uid of a genome release
- `list dbsnp <search_term>` retrieves taxids that can be used to find a dbsnp release
- `info dbsnp <taxid>` searches NCBI's FTP site for dbsnp vcfs for a given taxid and writes an FTP path to a Yaml file

Automating the downloading, merging and indexing of fastas/vcfs based on this metadata may be possible, but inconsistencies in FTP directory structures would make it difficult. See #17.
