### PR TITLE
Delivery script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ language: python
 python:
   - "3.3"
   - "3.4"
-install: "pip install -r requirements_no_pdf.txt"
-script: py.test
-# branches:
-#   only:
-#     - master
+install:
+  - "pip install -r requirements_no_pdf.txt"
+  - "pip install python-coveralls pytest-cov"
+  - "python setup.py install"
+script: py.test tests/ --doctest-modules  -v --cov bin --cov data_deletion --cov project_report--cov-report term-missing
+after_success:
+  - coveralls
 notifications:
   email:
     on_success: change # default: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 install:
   - "pip install -r requirements_no_pdf.txt"
   - "pip install python-coveralls pytest-cov"
-script: py.test tests/ --doctest-modules  -v --cov bin --cov data_deletion --cov project_report--cov-report term-missing
+script: py.test tests/ --doctest-modules  -v --cov bin --cov data_deletion --cov project_report --cov-report term-missing
 after_success:
   - coveralls
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 install:
   - "pip install -r requirements_no_pdf.txt"
   - "pip install python-coveralls pytest-cov"
-  - "python setup.py install"
 script: py.test tests/ --doctest-modules  -v --cov bin --cov data_deletion --cov project_report--cov-report term-missing
 after_success:
   - coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog for EGCG-Project-Management
 =====================================
 
+0.3
+---
+ - Delivery script support FluidX and send email confirmation.
+
 0.2.4
 -----
 - Fixed a bug where multiple non-human species in a project would crash `project_report`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog for EGCG-Project-Management
 
 0.3
 ---
- - Delivery script support FluidX and send email confirmation.
+ - Delivery script support FluidX and send email confirmation. (Change in configuration)
 
 0.2.4
 -----

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+EGCG-Project-Management
+===========
+[![travis](https://img.shields.io/travis/EdinburghGenomics/EGCG-Project-Management/master.svg)](https://travis-ci.org/EdinburghGenomics/EGCG-Project-Management)
+[![Coverage Status](https://coveralls.io/repos/github/EdinburghGenomics/EGCG-Project-Management/badge.svg)](https://coveralls.io/github/EdinburghGenomics/EGCG-Project-Management)
+[![GitHub issues](https://img.shields.io/github/issues/EdinburghGenomics/EGCG-Project-Management.svg)](https://github.com/EdinburghGenomics/EGCG-Project-Management/issues)

--- a/bin/deliver_reviewed_data.py
+++ b/bin/deliver_reviewed_data.py
@@ -103,8 +103,15 @@ class DataDelivery(AppLogger):
         return project_to_samples
 
     def stage_data(self, sample):
+        # test sample has arrived in fuildX tube
+        sample_id = sample.get(ELEMENT_SAMPLE_INTERNAL_ID)
+        fluidX_barcode = clarity.get_sample(sample_id).udf.get('2D Barcode')
+
         # Create staging_directory
-        sample_dir = os.path.join(self.staging_dir, sample.get(ELEMENT_SAMPLE_INTERNAL_ID))
+        if fluidX_barcode:
+            sample_dir = os.path.join(self.staging_dir, fluidX_barcode)
+        else:
+            sample_dir = os.path.join(self.staging_dir, sample_id)
         os.makedirs(sample_dir, exist_ok=True)
 
         # Find the fastq files

--- a/bin/deliver_reviewed_data.py
+++ b/bin/deliver_reviewed_data.py
@@ -52,8 +52,8 @@ class DataDelivery(AppLogger):
         self.sample2species = {}
         self.sample2analysis_type = {}
         self.work_dir = work_dir
-        today = datetime.date.today().isoformat()
-        self.staging_dir = os.path.join(self.work_dir, 'data_delivery_' + today)
+        now = datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
+        self.staging_dir = os.path.join(self.work_dir, 'data_delivery_' + now)
         self.no_cleanup = no_cleanup
         self.email = email
 

--- a/bin/deliver_reviewed_data.py
+++ b/bin/deliver_reviewed_data.py
@@ -483,10 +483,12 @@ def main():
     args = p.parse_args()
 
     load_config()
+    log_cfg.set_log_level(logging.INFO)
+    log_cfg.add_handler(logging.StreamHandler(stream=sys.stdout))
 
     if args.debug:
         log_cfg.set_log_level(logging.DEBUG)
-        log_cfg.add_handler(logging.StreamHandler(stream=sys.stdout))
+
 
     cfg.merge(cfg['sample'])
     dd = DataDelivery(args.dry_run, args.work_dir, no_cleanup=args.no_cleanup, email=args.email)

--- a/bin/deliver_reviewed_data.py
+++ b/bin/deliver_reviewed_data.py
@@ -13,6 +13,8 @@ from egcg_core.constants import ELEMENT_NB_READS_CLEANED, ELEMENT_RUN_NAME, ELEM
     ELEMENT_SAMPLE_INTERNAL_ID, ELEMENT_SAMPLE_EXTERNAL_ID, ELEMENT_RUN_ELEMENT_ID, ELEMENT_USEABLE
 from egcg_core.exceptions import EGCGError
 from egcg_core.util import find_fastqs
+from egcg_core.notifications import EmailNotification
+
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import load_config
@@ -39,11 +41,11 @@ other_list_files = []
 def _execute(*commands, **kwargs):
     exit_status = executor.execute(*commands, **kwargs).join()
     if exit_status != 0:
-        raise EGCGError('commands %s exited with status %s' % (commands, exit_status))
+        raise EGCGError('Commands %s exited with status %s' % (commands, exit_status))
 
 
 class DataDelivery(AppLogger):
-    def __init__(self, dry_run, work_dir, no_cleanup=False):
+    def __init__(self, dry_run, work_dir, no_cleanup=False, email=True):
         self.all_commands_for_cluster = []
         self.dry_run = dry_run
         self.all_samples_values = []
@@ -53,6 +55,7 @@ class DataDelivery(AppLogger):
         today = datetime.date.today().isoformat()
         self.staging_dir = os.path.join(self.work_dir, 'data_delivery_' + today)
         self.no_cleanup = no_cleanup
+        self.email = email
 
     def get_deliverable_projects_samples(self, project_id=None, sample_id=None):
         project_to_samples = defaultdict(list)
@@ -256,13 +259,13 @@ class DataDelivery(AppLogger):
                     )
         return fastqs_files
 
-    @staticmethod
-    def mark_samples_as_released(samples):
+    def mark_samples_as_released(self, samples):
         for sample_name in samples:
             rest_communication.patch_entry(
                 'samples', payload={'delivered': 'yes'}, id_field='sample_id', element_id=sample_name
             )
         clarity.route_samples_to_delivery_workflow(samples)
+        self.report('Marked %s samples as delivered' % len(samples))
 
     def mark_only(self, project_id=None, sample_id=None):
         project_to_samples = self.get_deliverable_projects_samples(project_id, sample_id)
@@ -272,7 +275,7 @@ class DataDelivery(AppLogger):
             for sample in samples:
                 all_samples.append(sample)
         if self.dry_run:
-            self.info('Mark %s samples as delivered' % len(all_samples))
+            self.info('Will mark %s samples as delivered' % len(all_samples))
         else:
             self.mark_samples_as_released(all_samples)
 
@@ -290,6 +293,7 @@ class DataDelivery(AppLogger):
 
     def run_aggregate_commands(self):
         if self.all_commands_for_cluster:
+            self.debug('Concatenating fastqs for %s samples', len(self.all_commands_for_cluster))
             _execute(
                 *self.all_commands_for_cluster,
                 job_name='concat_delivery',
@@ -323,6 +327,7 @@ class DataDelivery(AppLogger):
             return
         if os.path.exists(self.staging_dir):
             shutil.rmtree(self.staging_dir)
+            self.debug('Cleaned up staging dir %s', self.staging_dir)
 
     def deliver_data(self, project_id=None, sample_id=None):
         delivery_dest = cfg.query('delivery_dest')
@@ -361,11 +366,18 @@ class DataDelivery(AppLogger):
                                 batch_delivery_folder)
                 self.write_metrics_file(project, batch_delivery_folder)
                 self.generate_md5_summary(project, batch_delivery_folder)
+                self.report('Delivered %s samples for project %s' % (len(project_to_samples[project]), project))
 
             self.mark_samples_as_released(list(sample2stagedirectory))
 
         self.cleanup()
         # TODO: Generate project report
+
+    def report(self, msg):
+        self.info(msg)
+        if self.email:
+            e = EmailNotification('Data delivery', **cfg['email_notification'])
+            e.notify(msg)
 
 
 def main():
@@ -373,6 +385,7 @@ def main():
     p.add_argument('--dry_run', action='store_true')
     p.add_argument('--debug', action='store_true')
     p.add_argument('--no_cleanup', action='store_true')
+    p.add_argument('--noemail', dest='email', action='store_false')
     p.add_argument('--work_dir', type=str, required=True)
     p.add_argument('--mark_only', action='store_true')
     p.add_argument('--project_id', type=str)
@@ -386,7 +399,7 @@ def main():
         log_cfg.add_handler(logging.StreamHandler(stream=sys.stdout))
 
     cfg.merge(cfg['sample'])
-    dd = DataDelivery(args.dry_run, args.work_dir, no_cleanup=args.no_cleanup)
+    dd = DataDelivery(args.dry_run, args.work_dir, no_cleanup=args.no_cleanup, email=args.email)
     if args.mark_only:
         dd.mark_only(project_id=args.project_id, sample_id=args.sample_id)
     else:

--- a/etc/example_data_delivery.yaml
+++ b/etc/example_data_delivery.yaml
@@ -6,8 +6,19 @@ default:
 
     ncbi_cache: ':memory:'
 
-    delivery_source: tests/assets/data_delivery/source
-    delivery_dest: tests/assets/data_delivery/dest
+    delivery:
+        source: tests/assets/data_delivery/source
+        dest: tests/assets/data_delivery/dest
+        clarity_workflow_name: 'Data Release'
+        clarity_stage_name: 'Data Release'
+        email_notification:
+            mailhost: smtp.test.me
+            port: 25
+            sender: sender@email.com
+            recipients:
+              - recipient1@email.com
+              - recipient2@email.com
+
     input_dir: tests/assets/data_delivery/runs
 
     tools:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-EGCG-Core>=0.6.7
+EGCG-Core>=0.6.12
 jinja2==2.8
 weasyprint==0.30
 cached-property>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-EGCG-Core>=0.7
+EGCG-Core>=0.7.1
 jinja2==2.8
 weasyprint==0.30
 cached-property>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-EGCG-Core>=0.6.12
+EGCG-Core>=0.7
 jinja2==2.8
 weasyprint==0.30
 cached-property>=1.3.0

--- a/requirements_no_pdf.txt
+++ b/requirements_no_pdf.txt
@@ -1,3 +1,3 @@
-EGCG-Core>=0.6.7
+EGCG-Core>=0.6.12
 jinja2==2.8
 cached-property>=1.3.0

--- a/requirements_no_pdf.txt
+++ b/requirements_no_pdf.txt
@@ -1,3 +1,3 @@
-EGCG-Core>=0.6.12
+EGCG-Core>=0.7
 jinja2==2.8
 cached-property>=1.3.0

--- a/requirements_no_pdf.txt
+++ b/requirements_no_pdf.txt
@@ -1,3 +1,3 @@
-EGCG-Core>=0.7
+EGCG-Core>=0.7.1
 jinja2==2.8
 cached-property>=1.3.0

--- a/tests/test_data_delivery/test_data_delivery.py
+++ b/tests/test_data_delivery/test_data_delivery.py
@@ -144,8 +144,8 @@ class TestDataDelivery(TestProjectManagement):
 
     def setUp(self):
         os.makedirs(self.dest_dir, exist_ok=True)
-        self.delivery_dry = DataDelivery(dry_run=True, work_dir=os.path.join(self.assets_delivery, 'staging'), no_cleanup=True)
-        self.delivery_real = DataDelivery(dry_run=False, work_dir=os.path.join(self.assets_delivery, 'staging'))
+        self.delivery_dry = DataDelivery(dry_run=True, work_dir=os.path.join(self.assets_delivery, 'staging'), no_cleanup=True, email=False)
+        self.delivery_real = DataDelivery(dry_run=False, work_dir=os.path.join(self.assets_delivery, 'staging'), email=False)
         self._create_run_elements(sample1.get('run_elements') + sample2.get('run_elements'))
 
     def tearDown(self):

--- a/tests/test_data_delivery/test_data_delivery.py
+++ b/tests/test_data_delivery/test_data_delivery.py
@@ -215,8 +215,6 @@ class TestDataDelivery(TestProjectManagement):
                 assert header == expected_header
                 assert lines == expected_lines
 
-    # def test_generate_md5_summary(self):
-    #     self.delivery_dry.generate_md5_summary()
 
     def test_deliver_data_merged(self):
         with patched_deliverable_project1, patched_get_species,\

--- a/tests/test_data_delivery/test_data_delivery.py
+++ b/tests/test_data_delivery/test_data_delivery.py
@@ -296,13 +296,36 @@ class TestDataDelivery(TestProjectManagement):
 
 
     def test_email_report(self):
-        project_to_samples = {'test_project': [sample1, sample2]}
         with patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
-            msg = self.delivery_dry.create_email_report(project_to_samples)
+            msg = self.delivery_dry.create_email_report('test_project', [sample1, sample2])
             assert msg == '''Hi
-2 sample(s) from 1 project(s) have been delivered:
-  - test_project: 2 sample(s)
+2 samples from project test_project have been delivered:
 Consult delivery queue at
 http://testclarity.com/queue/999
-Regards
+template delivery email is appended bellow
+----
+Dear all,
+
+The data for 2 samples from project test_project has been released to our Aspera server at:
+https://tranfer.epcc.ed.ac.uk/test_project
+
+
+Your usernames are:
+[ENTER USERNAMES]
+
+Your passwords will be sent separately.
+
+Please see the link below for guidance on how to download:
+https://genomics.ed.ac.uk/resources/download-help-clinical
+
+
+The data for your project will be stored on our server for 3 months and deleted after this time. Please check your data for corruption once downloaded. Email notifications will be sent 1 month and 1 week before deletion.
+
+If you have any questions about the data or download then please don’t hesitate to contact me.
+
+Kind regards,
+
+[NAME]
+
+[SIGNATURE]
 '''

--- a/tests/test_data_delivery/test_data_delivery.py
+++ b/tests/test_data_delivery/test_data_delivery.py
@@ -219,7 +219,7 @@ class TestDataDelivery(TestProjectManagement):
     def test_deliver_data_merged(self):
         with patched_deliverable_project1, patched_get_species,\
                 patch('egcg_core.clarity.get_sample', return_value=Mock(udf={'Delivery': 'merged'})), \
-                patch('bin.deliver_reviewed_data.get_queue_uri', return_value='http://testclarity.com/queue/999'):
+                patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
             self.delivery_dry.deliver_data(project_id='test_project')
             assert os.listdir(self.delivery_dry.staging_dir) == ['deliverable_sample']
             list_files = sorted(os.listdir(os.path.join(self.delivery_dry.staging_dir, 'deliverable_sample')))
@@ -228,7 +228,7 @@ class TestDataDelivery(TestProjectManagement):
     def test_deliver_data_merged_concat(self):
         with patched_deliverable_project2, patched_get_species,\
                 patch('egcg_core.clarity.get_sample', return_value=Mock(udf={'Delivery': 'merged'})), \
-             patch('bin.deliver_reviewed_data.get_queue_uri', return_value='http://testclarity.com/queue/999'):
+             patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
             self.delivery_dry.deliver_data(project_id='test_project')
             assert os.listdir(self.delivery_dry.staging_dir) == ['deliverable_sample2']
             list_files = sorted(os.listdir(os.path.join(self.delivery_dry.staging_dir, 'deliverable_sample2')))
@@ -237,8 +237,8 @@ class TestDataDelivery(TestProjectManagement):
 
     def test_deliver_data_split(self):
         with patched_deliverable_project1, patched_get_species,\
-                patch('egcg_core.clarity.get_sample', return_value=Mock(udf={'Delivery': 'split'})), \
-             patch('bin.deliver_reviewed_data.get_queue_uri', return_value='http://testclarity.com/queue/999'):
+             patch('egcg_core.clarity.get_sample', return_value=Mock(udf={'Delivery': 'split'})), \
+             patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
             self.delivery_dry.deliver_data(project_id='test_project')
             assert os.listdir(self.delivery_dry.staging_dir) == ['deliverable_sample']
             list_files = sorted(os.listdir(os.path.join(self.delivery_dry.staging_dir, 'deliverable_sample')))
@@ -247,7 +247,7 @@ class TestDataDelivery(TestProjectManagement):
     def test_deliver_data_fluidx(self):
         with patched_deliverable_project1, patched_get_species,\
                 patch('egcg_core.clarity.get_sample', return_value=Mock(udf={'2D Barcode': 'FluidXBarcode', 'Delivery': 'split'})), \
-             patch('bin.deliver_reviewed_data.get_queue_uri', return_value='http://testclarity.com/queue/999'):
+             patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
             self.delivery_dry.deliver_data(project_id='test_project')
             assert os.listdir(self.delivery_dry.staging_dir) == ['FluidXBarcode']
             list_files = sorted(os.listdir(os.path.join(self.delivery_dry.staging_dir, 'FluidXBarcode')))
@@ -258,7 +258,7 @@ class TestDataDelivery(TestProjectManagement):
                 patch('egcg_core.clarity.get_sample', return_value=Mock(udf={'Delivery': 'merged'})),\
                 patch.object(DataDelivery, 'run_aggregate_commands'),\
                 patch('bin.deliver_reviewed_data.DataDelivery.mark_samples_as_released'), \
-                patch('bin.deliver_reviewed_data.get_queue_uri', return_value='http://testclarity.com/queue/999'):
+                patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
             self.delivery_real.deliver_data(project_id='test_project')
             assert os.listdir(self.dest_dir) == ['test_project']
             today = datetime.date.today().isoformat()
@@ -272,7 +272,7 @@ class TestDataDelivery(TestProjectManagement):
              patch('egcg_core.clarity.get_sample', return_value=Mock(udf={'Delivery': 'split'})),\
              patch.object(DataDelivery, 'run_aggregate_commands'),\
              patch('bin.deliver_reviewed_data.DataDelivery.mark_samples_as_released'), \
-             patch('bin.deliver_reviewed_data.get_queue_uri', return_value='http://testclarity.com/queue/999'):
+             patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
             self.delivery_real.deliver_data(project_id='test_project')
             assert os.listdir(self.dest_dir) == ['test_project']
             today = datetime.date.today().isoformat()
@@ -297,7 +297,7 @@ class TestDataDelivery(TestProjectManagement):
 
     def test_email_report(self):
         project_to_samples = {'test_project': [sample1, sample2]}
-        with patch('bin.deliver_reviewed_data.get_queue_uri', return_value='http://testclarity.com/queue/999'):
+        with patch('egcg_core.clarity.get_queue_uri', return_value='http://testclarity.com/queue/999'):
             msg = self.delivery_dry.create_email_report(project_to_samples)
             assert msg == '''Hi
 2 sample(s) from 1 project(s) have been delivered:


### PR DESCRIPTION
This PR address multiple issues affecting the delivery scripts:
 - Fixes the staging directory name to be unique: fixes #8 
 - Sends an email after data delivery specifying the projects and number of samples delivered, also generates and attaches the project reports pdf files: fixes #14 
 - Add support for Samples delivered in fluidX tube by renaming the sample folder with the fluidX 2D barcode: fixes #22 
 - Register all files delivered to the Reporting app: fixes #25 

It also change the config file format requirements