### PR TITLE
Tape recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog for EGCG-Project-Management
 0.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added recall_sample.py for recalling a sample from tape
 
 
 0.4 (2017-10-23)

--- a/bin/recall_sample.py
+++ b/bin/recall_sample.py
@@ -1,6 +1,8 @@
 import argparse
+from os import listdir
 from shutil import disk_usage
 from egcg_core import rest_communication, archive_management as am
+from egcg_core.util import find_files
 from egcg_core.app_logging import logging_default
 from egcg_core.exceptions import EGCGError
 from config import cfg, load_config
@@ -25,7 +27,7 @@ def main(argv=None):
 
 def file_states(sample_id):
     s = ProcessedSample(rest_communication.get_document('aggregate/samples', match={'sample_id': sample_id}))
-    return {f: sorted(am.archive_states(f)) for f in s.processed_data_files}
+    return {f: sorted(am.archive_states(f)) for f in find_files(s.released_data_folder, '*')}
 
 
 def check(sample_id):
@@ -48,11 +50,11 @@ def check(sample_id):
     logger.info(
         'Found %s files: %s restorable (%s Gb), %s dirty (%s Gb), %s unarchived (%s Gb)',
         len(fstates),
-        len(dirty_files),
+        len(restorable_files),
         get_file_list_size(restorable_files) / 1000000000,
         len(unarchived_files),
         get_file_list_size(dirty_files) / 1000000000,
-        len(restorable_files),
+        len(dirty_files),
         get_file_list_size(unarchived_files) / 1000000000
     )
     return restorable_files, unarchived_files, dirty_files

--- a/bin/recall_sample.py
+++ b/bin/recall_sample.py
@@ -1,0 +1,87 @@
+import argparse
+from shutil import disk_usage
+from egcg_core import rest_communication, archive_management as am
+from egcg_core.app_logging import logging_default
+from egcg_core.exceptions import EGCGError
+from config import cfg, load_config
+from data_deletion import ProcessedSample, get_file_list_size
+
+logging_default.add_stdout_handler()
+logger = logging_default.get_logger(__name__)
+
+
+def main(argv=None):
+    a = argparse.ArgumentParser()
+    a.add_argument('action', choices=('check', 'restore'))
+    a.add_argument('sample_id')
+    args = a.parse_args(argv)
+    load_config()
+
+    if args.action == 'check':
+        check(args.sample_id)
+    elif args.action == 'restore':
+        restore(args.sample_id)
+
+
+def file_states(sample_id):
+    s = ProcessedSample(rest_communication.get_document('aggregate/samples', match={'sample_id': sample_id}))
+    return {f: sorted(am.archive_states(f)) for f in s.processed_data_files}
+
+
+def check(sample_id):
+    fstates = file_states(sample_id)
+    logger.debug('Found %s files', len(fstates))
+
+    restorable_files = []
+    unarchived_files = []
+    dirty_files = []
+    for f, states in fstates.items():
+        if am.is_dirty(f, states):
+            target_list = dirty_files
+        elif am.is_released(f, states):
+            target_list = restorable_files
+        else:
+            target_list = unarchived_files
+        target_list.append(f)
+
+    logger.info(
+        'Found %s files: %s restorable (%s Gb), %s dirty (%s Gb), %s unarchived (%s Gb)',
+        len(fstates),
+        len(dirty_files),
+        get_file_list_size(restorable_files) / 1000000000,
+        len(unarchived_files),
+        get_file_list_size(dirty_files) / 1000000000,
+        len(restorable_files),
+        get_file_list_size(unarchived_files) / 1000000000
+    )
+    return restorable_files, unarchived_files, dirty_files
+
+
+def restore(sample_id):
+    if disk_usage(cfg['data_deletion']['delivered_data']).free < 50000000000000:  # TODO: refactor config
+        raise EGCGError('Unsafe to recall: less than 50Tb free')
+
+    files_to_restore, files_not_archived, dirty_files = check(sample_id)
+
+    if dirty_files:
+        raise EGCGError('Found %s dirty files: %s' % (len(dirty_files), dirty_files))
+
+    if files_not_archived:
+        logger.warning(
+            'Found %s files not archived. Have they already been restored? %s',
+            len(files_not_archived),
+            files_not_archived
+        )
+    if not files_to_restore:
+        logger.info('No files to restore found - nothing to do')
+        return None
+
+    logger.info('Recalling %s files: %s', len(files_to_restore), files_to_restore)
+    for f in files_to_restore:
+        am.recall_from_tape(f)
+
+    rest_communication.patch_entry('samples', {'data_deleted': 'none'}, 'sample_id', sample_id)
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/recall_sample.py
+++ b/bin/recall_sample.py
@@ -1,8 +1,6 @@
 import argparse
-from os import listdir
 from shutil import disk_usage
 from egcg_core import rest_communication, archive_management as am
-from egcg_core.util import find_files
 from egcg_core.app_logging import logging_default
 from egcg_core.exceptions import EGCGError
 from config import cfg, load_config
@@ -27,7 +25,7 @@ def main(argv=None):
 
 def file_states(sample_id):
     s = ProcessedSample(rest_communication.get_document('aggregate/samples', match={'sample_id': sample_id}))
-    return {f: sorted(am.archive_states(f)) for f in find_files(s.released_data_folder, '*')}
+    return {f: sorted(am.archive_states(f)) for f in s.raw_data_files + s.processed_data_files}
 
 
 def check(sample_id):

--- a/bin/recall_sample.py
+++ b/bin/recall_sample.py
@@ -35,7 +35,8 @@ def check(sample_id):
     restorable_files = []
     unarchived_files = []
     dirty_files = []
-    for f, states in fstates.items():
+    for f in sorted(fstates):
+        states = fstates[f]
         if am.is_dirty(f, states):
             target_list = dirty_files
         elif am.is_released(f, states):

--- a/bin/recall_sample.py
+++ b/bin/recall_sample.py
@@ -66,12 +66,13 @@ def restore(sample_id):
 
     files_to_restore, files_not_released, files_not_archived, dirty_files = check(sample_id)
 
-    if dirty_files:
-        raise EGCGError('Found %s dirty files: %s' % (len(dirty_files), dirty_files))
+    if dirty_files or files_not_archived:
+        logger.error('Found %s dirty files: %s', len(dirty_files), dirty_files)
+        logger.error('Found %s files not archived: %s', len(files_not_archived), files_not_archived)
+        raise EGCGError('Found %s dirty, %s unarchived files' % (len(dirty_files), len(files_not_archived)))
+
     if files_not_released:
         logger.warning('Found %s files not released: %s', len(files_not_released), files_not_released)
-    if files_not_archived:
-        logger.warning('Found %s files not archived: %s', len(files_not_archived), files_not_archived)
 
     if not files_to_restore:
         logger.info('No files to restore found - nothing to do')

--- a/data_deletion/__init__.py
+++ b/data_deletion/__init__.py
@@ -111,7 +111,7 @@ class ProcessedSample(AppLogger):
     @cached_property
     def run_elements(self):
         return rest_communication.get_documents(
-                'run_elements', quiet=True, where={ELEMENT_SAMPLE_INTERNAL_ID: self.sample_id}, all_pages=True
+            'run_elements', quiet=True, where={ELEMENT_SAMPLE_INTERNAL_ID: self.sample_id}, all_pages=True
         )
 
     @cached_property
@@ -133,7 +133,7 @@ class ProcessedSample(AppLogger):
 
     @cached_property
     def processed_data_files(self):
-        files_to_delete = []
+        files = []
         # TODO: first check what type of analysis was perfomed on this data to know exactly which files need to be deleted
         files_to_search = [
             '{ext_s_id}_R1.fastq.gz', '{ext_s_id}_R2.fastq.gz',
@@ -141,15 +141,15 @@ class ProcessedSample(AppLogger):
             '{ext_s_id}.vcf.gz', '{ext_s_id}.vcf.gz.tbi',
             '{ext_s_id}.g.vcf.gz', '{ext_s_id}.g.vcf.gz.tbi'
         ]
-        for f in files_to_search:
-            file_to_delete = util.find_file(
+        for basename in files_to_search:
+            f = util.find_file(
                 self.processed_data_dir,
                 self.project_id, self.sample_id,
-                f.format(ext_s_id=self.external_sample_id)
+                basename.format(ext_s_id=self.external_sample_id)
             )
-            if file_to_delete:
-                files_to_delete.append(file_to_delete)
-        return files_to_delete
+            if f:
+                files.append(f)
+        return files
 
     @cached_property
     def released_data_folder(self):

--- a/data_deletion/__init__.py
+++ b/data_deletion/__init__.py
@@ -1,16 +1,14 @@
-from datetime import datetime
 from os import listdir, stat
 from os.path import join, isdir
-
+from datetime import datetime
 from cached_property import cached_property
-
 from egcg_core import app_logging, executor, clarity, rest_communication, util
 from egcg_core.app_logging import AppLogger
 from egcg_core.archive_management import is_archived, ArchivingError
 from egcg_core.config import cfg
+from egcg_core.exceptions import EGCGError
 from egcg_core.constants import ELEMENT_SAMPLE_INTERNAL_ID, ELEMENT_PROJECT_ID, ELEMENT_SAMPLE_EXTERNAL_ID, \
     ELEMENT_RUN_NAME, ELEMENT_LANE
-from egcg_core.exceptions import EGCGError
 
 
 def get_file_list_size(file_list):
@@ -124,28 +122,23 @@ class ProcessedSample(AppLogger):
                 all_fastqs.extend(fastqs)
             else:
                 self.warning(
-                    'No fastqs found for run %s lane %s sample %s',
-                    e[ELEMENT_RUN_NAME],
-                    e[ELEMENT_LANE],
-                    self.sample_id
+                    'No fastqs found for run %s lane %s sample %s', e[ELEMENT_RUN_NAME], e[ELEMENT_LANE], self.sample_id
                 )
         return all_fastqs
 
     @cached_property
     def processed_data_files(self):
         files = []
-        # TODO: first check what type of analysis was perfomed on this data to know exactly which files need to be deleted
-        files_to_search = [
-            '{ext_s_id}_R1.fastq.gz', '{ext_s_id}_R2.fastq.gz',
-            '{ext_s_id}.bam', '{ext_s_id}.bam.bai',
-            '{ext_s_id}.vcf.gz', '{ext_s_id}.vcf.gz.tbi',
-            '{ext_s_id}.g.vcf.gz', '{ext_s_id}.g.vcf.gz.tbi'
-        ]
-        for basename in files_to_search:
+        # TODO: check what type of analysis was perfomed on this data to know exactly which files should be there
+        file_extensions = ('_R1.fastq.gz', '_R2.fastq.gz', '.bam', '.bam.bai',
+                           '.vcf.gz', '.vcf.gz.tbi', '.g.vcf.gz', '.g.vcf.gz.tbi')
+
+        for ext in file_extensions:
             f = util.find_file(
                 self.processed_data_dir,
-                self.project_id, self.sample_id,
-                basename.format(ext_s_id=self.external_sample_id)
+                self.project_id,
+                self.sample_id,
+                self.external_sample_id + ext
             )
             if f:
                 files.append(f)

--- a/tests/test_recall_sample.py
+++ b/tests/test_recall_sample.py
@@ -1,0 +1,69 @@
+from os.path import join
+from unittest.mock import patch
+from bin import recall_sample
+from tests import TestProjectManagement
+from egcg_core.exceptions import EGCGError
+import logging
+
+
+def fake_find_file(*parts):
+    return join(*parts)
+
+
+class TestRecall(TestProjectManagement):
+    fake_file_states = {
+        'this.vcf.gz': ['exists', 'archived', 'released'],
+        'this.bam': [],
+        'this_r1.fastq.gz': ['exists', 'dirty', 'archived'],
+        'this_r2.fastq.gz': ['exists', 'archived']
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        recall_sample.cfg.load_config_file(join(cls.root_path, 'etc', 'example_data_deletion.yaml'))
+
+    @patch('bin.recall_sample.file_states', return_value=fake_file_states)
+    @patch('bin.recall_sample.get_file_list_size', return_value=1000000000)
+    @patch('egcg_core.archive_management.archive_states', return_value=[])
+    def test_check(self, mocked_archive_states, mocked_file_size, mocked_file_states):
+        assert recall_sample.check('a_sample_id') == (
+            ['this.vcf.gz'],
+            ['this.bam', 'this_r2.fastq.gz'],
+            ['this_r1.fastq.gz']
+        )
+
+    @patch('bin.recall_sample.logger._log')
+    @patch('bin.recall_sample.rest_communication.patch_entry')
+    @patch('bin.recall_sample.am.recall_from_tape')
+    @patch('bin.recall_sample.disk_usage')
+    @patch('bin.recall_sample.check')
+    def test_restore(self, mocked_check, mocked_disk_usage, mocked_recall, mocked_patch, mocked_log):
+        mocked_disk_usage.return_value.free = 1
+        with self.assertRaises(EGCGError) as e:
+            recall_sample.restore('a_sample_id')
+
+        assert str(e.exception) == 'Unsafe to recall: less than 50Tb free'
+        mocked_check.assert_not_called()
+        mocked_disk_usage.return_value.free = 50000000000000
+
+        mocked_check.return_value = ([], [], ['dirty', 'files'])
+        with self.assertRaises(EGCGError) as e:
+            recall_sample.restore('a_sample_id')
+
+        assert str(e.exception) == "Found 2 dirty files: ['dirty', 'files']"
+
+        mocked_check.return_value = ([], ['unarchived', 'files'], [])
+        recall_sample.restore('a_sample_id')
+        mocked_log.assert_any_call(
+            logging.WARNING,
+            'Found %s files not archived. Have they already been restored? %s',
+            (2, ['unarchived', 'files'])
+        )
+
+        mocked_check.return_value = (['restorable', 'files'], [], [])
+        recall_sample.restore('a_sample_id')
+
+        for f in ['restorable', 'files']:
+            mocked_recall.assert_any_call(f)
+
+        mocked_patch.assert_called_with('samples', {'data_deleted': 'none'}, 'sample_id', 'a_sample_id')

--- a/tests/test_recall_sample.py
+++ b/tests/test_recall_sample.py
@@ -65,15 +65,19 @@ class TestRecall(TestProjectManagement):
         with self.assertRaises(EGCGError) as e:
             recall_sample.restore('a_sample_id')
 
-        assert str(e.exception) == "Found 2 dirty files: ['dirty', 'files']"
+        mocked_log.assert_any_call(logging.ERROR, 'Found %s dirty files: %s', (2, ['dirty', 'files']))
+        assert str(e.exception) == 'Found 2 dirty, 0 unarchived files'
 
         mocked_check.return_value = ([], ['unreleased', 'files'], [], [])
         recall_sample.restore('a_sample_id')
         mocked_log.assert_any_call(logging.WARNING, 'Found %s files not released: %s', (2, ['unreleased', 'files']))
 
         mocked_check.return_value = ([], [], ['unarchived', 'files'], [])
-        recall_sample.restore('a_sample_id')
-        mocked_log.assert_any_call(logging.WARNING, 'Found %s files not archived: %s', (2, ['unarchived', 'files']))
+        with self.assertRaises(EGCGError) as e:
+            recall_sample.restore('a_sample_id')
+
+        mocked_log.assert_any_call(logging.ERROR, 'Found %s files not archived: %s', (2, ['unarchived', 'files']))
+        assert str(e.exception) == 'Found 0 dirty, 2 unarchived files'
 
         mocked_check.return_value = (['restorable', 'files'], [], [], [])
         recall_sample.restore('a_sample_id')

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,93 +1,89 @@
 from bin import reference_data
 from unittest.mock import Mock, MagicMock, patch
 from tests import TestProjectManagement
-reference_data.cfg.load_config_file(TestProjectManagement.etc_config)
 
 ppath = 'bin.reference_data.'
 
 
-@patch(ppath + 'requests.get')
-def test_query_ncbi(mocked_get):
-    reference_data._query_ncbi('an_eutil', 'a_db', this='that', other='another')
-    mocked_get.assert_called_with(
-        'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/an_eutil.fcgi',
-        {'db': 'a_db', 'retmode': 'JSON', 'version': '2.0', 'this': 'that', 'other': 'another'}
-    )
-
-
-@patch(ppath + '_query_ncbi', return_value={'esearchresult': {'count': 2, 'idlist': [1337]}})
-def test_list_ids(mocked_query):
-    assert reference_data.list_ids('a_db', 'Thingius thingy') == [1337]
-    mocked_query.assert_called_with('esearch', 'a_db', term='Thingius thingy', retmax=20)
-
-
-fake_esummary = {
-    'result': {
-        'uids': ['11337', '11338'],
-        '11337': {'uid': '11337', 'assemblyname': 'tThi_1.337', 'speciesname': 'Thingius thingy',
-                  'organism': 'Thingius thingy (some kind of flappy swimmy thing)', 'speciestaxid': '1337',
-                  'seqreleasedate': 'then', 'ftppath_genbank': 'an_ftp_site/tThi_1.338/'},
-        '11338': {'uid': '11338', 'assemblyname': 'tThi_1.338', 'speciesname': 'Thingius thingy',
-                  'speciestaxid': '1337', 'seqreleasedate': 'now', 'ftppath_genbank': None}
+class TestReferenceData(TestProjectManagement):
+    fake_esummary = {
+        'result': {
+            'uids': ['11337', '11338'],
+            '11337': {'uid': '11337', 'assemblyname': 'tThi_1.337', 'speciesname': 'Thingius thingy',
+                      'organism': 'Thingius thingy (some kind of flappy swimmy thing)', 'speciestaxid': '1337',
+                      'seqreleasedate': 'then', 'ftppath_genbank': 'an_ftp_site/tThi_1.338/'},
+            '11338': {'uid': '11338', 'assemblyname': 'tThi_1.338', 'speciesname': 'Thingius thingy',
+                      'speciestaxid': '1337', 'seqreleasedate': 'now', 'ftppath_genbank': None}
+        }
     }
-}
+    fake_mlsds = [
+        {'thing_11337': None},
+        {'VCF': None, '.': None, '..': None}
+    ]
 
+    @classmethod
+    def setUpClass(cls):
+        reference_data.cfg.load_config_file(cls.etc_config)
 
-@patch(ppath + 'list_ids', return_value=['11337', '11338'])
-@patch(ppath + '_query_ncbi', return_value=fake_esummary)
-@patch('builtins.print')
-def test_list_reference_genomes(mocked_print, mocked_query, mocked_list_ids):
-    reference_data.list_reference_genomes('Thingius thingy')
-    mocked_list_ids.assert_called_with('assembly', 'Thingius thingy')
-    mocked_query.assert_called_with('esummary', 'assembly', id='11337,11338')
-    for s in ('11337 tThi_1.337, species Thingius thingy (1337), released then, ftp=an_ftp_site/tThi_1.338/',
-              '11338 tThi_1.338, species Thingius thingy (1337), released now, ftp=(no ftp available)'):
-        mocked_print.assert_any_call(s)
+    @patch(ppath + 'requests.get')
+    def test_query_ncbi(self, mocked_get):
+        reference_data._query_ncbi('an_eutil', 'a_db', this='that', other='another')
+        mocked_get.assert_called_with(
+            'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/an_eutil.fcgi',
+            {'db': 'a_db', 'retmode': 'JSON', 'version': '2.0', 'this': 'that', 'other': 'another'}
+        )
 
+    @patch(ppath + '_query_ncbi', return_value={'esearchresult': {'count': 2, 'idlist': [1337]}})
+    def test_list_ids(self, mocked_query):
+        assert reference_data.list_ids('a_db', 'Thingius thingy') == [1337]
+        mocked_query.assert_called_with('esearch', 'a_db', term='Thingius thingy', retmax=20)
 
-@patch(ppath + 'yaml')
-@patch('builtins.open', return_value=MagicMock())
-def test_record_reference_data(mocked_open, mocked_yaml):
-    with patch(ppath + '_now', return_value='now'), patch(ppath + 'os.makedirs'):
-        reference_data.record_reference_data('Thingius thingy', 'tThi_1.337', {'some': 'metadata'})
+    @patch(ppath + 'list_ids', return_value=['11337', '11338'])
+    @patch(ppath + '_query_ncbi', return_value=fake_esummary)
+    @patch('builtins.print')
+    def test_list_reference_genomes(self, mocked_print, mocked_query, mocked_list_ids):
+        reference_data.list_reference_genomes('Thingius thingy')
+        mocked_list_ids.assert_called_with('assembly', 'Thingius thingy')
+        mocked_query.assert_called_with('esummary', 'assembly', id='11337,11338')
+        for s in ('11337 tThi_1.337, species Thingius thingy (1337), released then, ftp=an_ftp_site/tThi_1.338/',
+                  '11338 tThi_1.338, species Thingius thingy (1337), released now, ftp=(no ftp available)'):
+            mocked_print.assert_any_call(s)
 
-    mocked_open.assert_called_with('path/to/reference_data/Thingius_thingy/metadata.yaml', 'w')
-    mocked_file = mocked_open().__enter__()
-    mocked_file.write.assert_any_call('# metadata for Thingius thingy, last modified now\n')
-    mocked_yaml.safe_dump.assert_called_with(
-        {'tThi_1.337': {'date_downloaded': 'now', 'some': 'metadata'}},
-        mocked_file, indent=4, default_flow_style=False
-    )
+    @patch(ppath + 'yaml')
+    @patch('builtins.open', return_value=MagicMock())
+    def test_record_reference_data(self, mocked_open, mocked_yaml):
+        with patch(ppath + '_now', return_value='now'), patch(ppath + 'os.makedirs'):
+            reference_data.record_reference_data('Thingius thingy', 'tThi_1.337', {'some': 'metadata'})
 
+        mocked_open.assert_called_with('path/to/reference_data/Thingius_thingy/metadata.yaml', 'w')
+        mocked_file = mocked_open().__enter__()
+        mocked_file.write.assert_any_call('# metadata for Thingius thingy, last modified now\n')
+        mocked_yaml.safe_dump.assert_called_with(
+            {'tThi_1.337': {'date_downloaded': 'now', 'some': 'metadata'}},
+            mocked_file, indent=4, default_flow_style=False
+        )
 
-@patch(ppath + '_query_ncbi', return_value=fake_esummary)
-@patch(ppath + 'record_reference_data')
-def test_get_reference_genome(mocked_record, mocked_query):
-    reference_data.get_reference_genome('11337')
-    mocked_query.assert_called_with('esummary', 'assembly', id='11337')
-    mocked_record.assert_called_with(
-        'Thingius thingy',
-        'tThi_1.337',
-        {'uid': '11337', 'assemblyname': 'tThi_1.337',
-         'organism': 'Thingius thingy (some kind of flappy swimmy thing)', 'speciestaxid': '1337',
-            'seqreleasedate': 'then', 'ftppath_genbank': 'an_ftp_site/tThi_1.338/'}
-    )
+    @patch(ppath + '_query_ncbi', return_value=fake_esummary)
+    @patch(ppath + 'record_reference_data')
+    def test_get_reference_genome(self, mocked_record, mocked_query):
+        reference_data.get_reference_genome('11337')
+        mocked_query.assert_called_with('esummary', 'assembly', id='11337')
+        mocked_record.assert_called_with(
+            'Thingius thingy',
+            'tThi_1.337',
+            {'uid': '11337', 'assemblyname': 'tThi_1.337',
+             'organism': 'Thingius thingy (some kind of flappy swimmy thing)', 'speciestaxid': '1337',
+             'seqreleasedate': 'then', 'ftppath_genbank': 'an_ftp_site/tThi_1.338/'}
+        )
 
-
-fake_mlsds = [
-    {'thing_11337': None},
-    {'VCF': None, '.': None, '..': None}
-]
-
-
-@patch(ppath + 'record_reference_data')
-@patch('ftplib.FTP', return_value=Mock(mlsd=Mock(side_effect=fake_mlsds)))
-def test_get_dbsnp(mocked_ftp, mocked_record):
-    with patch(ppath + '_query_ncbi', return_value={'result': {'11337': {'scientificname': 'Thingius thingy'}}}):
-        reference_data.get_dbsnp('11337')
-    mocked_ftp().mlsd.assert_any_call('snp/organisms/thing_11337')
-    mocked_record.assert_called_with(
-        'Thingius thingy',
-        'dbsnp',
-        {'ftp': 'ftp://ftp.ncbi.nlm.nih.gov/snp/organisms/thing_11337/VCF', 'taxid': '11337'}
-    )
+    @patch(ppath + 'record_reference_data')
+    @patch('ftplib.FTP', return_value=Mock(mlsd=Mock(side_effect=fake_mlsds)))
+    def test_get_dbsnp(self, mocked_ftp, mocked_record):
+        with patch(ppath + '_query_ncbi', return_value={'result': {'11337': {'scientificname': 'Thingius thingy'}}}):
+            reference_data.get_dbsnp('11337')
+        mocked_ftp().mlsd.assert_any_call('snp/organisms/thing_11337')
+        mocked_record.assert_called_with(
+            'Thingius thingy',
+            'dbsnp',
+            {'ftp': 'ftp://ftp.ncbi.nlm.nih.gov/snp/organisms/thing_11337/VCF', 'taxid': '11337'}
+        )


### PR DESCRIPTION
Adds recall_sample.py. Scans all files for a sample, does an `lfs hsm_state` and if specified, does an `lfs hsm_restore`. Closes #39.