### PR TITLE
Gel delivery reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,70 @@
-EGCG-Project-Management
-===========
+# EGCG-Project-Management
+
 [![travis](https://img.shields.io/travis/EdinburghGenomics/EGCG-Project-Management/master.svg)](https://travis-ci.org/EdinburghGenomics/EGCG-Project-Management)
 [![Coverage Status](https://coveralls.io/repos/github/EdinburghGenomics/EGCG-Project-Management/badge.svg)](https://coveralls.io/github/EdinburghGenomics/EGCG-Project-Management)
 [![GitHub issues](https://img.shields.io/github/issues/EdinburghGenomics/EGCG-Project-Management.svg)](https://github.com/EdinburghGenomics/EGCG-Project-Management/issues)
+
+
+## GeL delivery
+The script `bin/deliver_data_to_gel.py` handles delivery of data via GeL's Rest API and can report on GeL deliveries.
+Data upload attempts are stored in a local sqlite database, as well as in GeL's Rest API. The script's usage is as
+follows:
+
+### Delivering data
+`python bin/deliver_data_to_gel.py --sample_id <sample_id>`
+
+Alternatively, `--user_sample_id` can be used, which will resolve the sample ID from the `User Sample Name` Lims UDF.
+This will:
+
+- locate the data to deliver
+- check that it has not already been successfully uploaded
+- concatenate all relevant `fastq.gz.md5` files into a single md5 report
+- create a new delivery record in GeL's Rest API if a delivery attempt has never been made
+- rsync the data across
+- if the rsync was successful, mark the delivery as successful
+- if the rsync failed, mark the delivery as failed
+- cleanup intermediate files
+
+Argument options:
+
+- `--force_new_delivery`: always create a new delivery record and re-upload data, even if previously successful
+- `--dry_run`: print a summary of what will be delivered, then exit
+- `--no_cleanup`: don't clean up files at the end
+
+
+### Reporting on deliveries
+The script can also report on the status of GeL deliveries so far. To do this, it queries each sample in the local
+sqlite database against GeL's Rest API. First, it is necessary to ensure that the local database is up to date:
+
+`python bin/deliver_data_to_gel.py --check_all_deliveries`
+
+Then the database can be reported on:
+
+`python bin/deliver_data_to_gel.py --report`
+
+This should give an output like:
+
+```
+id   sample_id   external_sample_id  creation_date          upload_state    upload_confirm_date    md5_state    md5_confirm_date       qc_state    qc_confirm_date        failure_reason
+1    sample_1    sample_a            2018-04-04 12:00:00    passed          2018-04-04 12:10:00    passed       2018-04-04 12:20:00    passed      2018-04-04 12:30:00    None
+2    sample_2    sample_b            2018-04-04 13:00:00    passed          2018-04-04 13:10:00    passed       2018-04-04 13:20:00    passed      2018-04-04 13:30:00    None
+```
+
+Note that because the sqlite database is the reference we're using for deliveries, `--check_all_deliveries` will only
+update existing delivery records, not add new ones that for some reason exist in GeL's API and not the local database.
+
+
+### Configuration
+
+- gel_upload
+  - delivery_db (local sqlite database)
+  - ssh_key (rsync ssh key)
+  - username (rsync user name)
+  - host (remote GeL data server)
+  - dest (target data location on remote server)
+  - rest_api
+    - host (remote GeL API server)
+    - user
+    - pswd
+- delivery
+  - dest (local output data location)

--- a/bin/deliver_data_to_gel.py
+++ b/bin/deliver_data_to_gel.py
@@ -1,12 +1,13 @@
-import argparse
-import logging
-import sys
 import os
+import sys
+import logging
+import argparse
 from egcg_core.app_logging import logging_default as log_cfg
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import load_config
-from upload_to_gel.deliver_data_to_gel import GelDataDelivery, check_all_md5sums
+from upload_to_gel.deliver_data_to_gel import GelDataDelivery, check_all_md5sums, report
+
 
 def main():
     p = argparse.ArgumentParser()
@@ -18,18 +19,20 @@ def main():
     group.add_argument('--user_sample_id', type=str)
     p.add_argument('--force_new_delivery', action='store_true')
     p.add_argument('--no_cleanup', action='store_true')
-    p.add_argument('--check_all_md5', action='store_true')
+    p.add_argument('--check_all_md5sums', action='store_true')
+    p.add_argument('--report')
 
     args = p.parse_args()
-
     load_config()
 
     if args.debug:
         log_cfg.set_log_level(logging.DEBUG)
         log_cfg.add_handler(logging.StreamHandler(stream=sys.stdout))
 
-    if args.check_all_md5:
+    if args.check_all_md5sums:
         check_all_md5sums(args.work_dir)
+    elif args.report:
+        report()
     else:
         gel_delivery = GelDataDelivery(args.work_dir, sample_id=args.sample_id, user_sample_id=args.user_sample_id,
                                        no_cleanup=args.no_cleanup, dry_run=args.dry_run, force_new_delivery=args.force_new_delivery)

--- a/bin/deliver_data_to_gel.py
+++ b/bin/deliver_data_to_gel.py
@@ -6,7 +6,7 @@ from egcg_core.app_logging import logging_default as log_cfg
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import load_config
-from upload_to_gel.deliver_data_to_gel import GelDataDelivery, check_all_md5sums, report
+from upload_to_gel.deliver_data_to_gel import GelDataDelivery, check_all_deliveries, report_all
 
 
 def main():
@@ -20,7 +20,7 @@ def main():
     p.add_argument('--force_new_delivery', action='store_true')
     p.add_argument('--no_cleanup', action='store_true')
     p.add_argument('--check_all_md5sums', action='store_true')
-    p.add_argument('--report')
+    p.add_argument('--report', action='store_true')
 
     args = p.parse_args()
     load_config()
@@ -30,9 +30,9 @@ def main():
         log_cfg.add_handler(logging.StreamHandler(stream=sys.stdout))
 
     if args.check_all_md5sums:
-        check_all_md5sums(args.work_dir)
+        check_all_deliveries(args.work_dir)
     elif args.report:
-        report()
+        report_all()
     else:
         gel_delivery = GelDataDelivery(args.work_dir, sample_id=args.sample_id, user_sample_id=args.user_sample_id,
                                        no_cleanup=args.no_cleanup, dry_run=args.dry_run, force_new_delivery=args.force_new_delivery)

--- a/bin/deliver_data_to_gel.py
+++ b/bin/deliver_data_to_gel.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import logging
 import argparse
 from egcg_core.app_logging import logging_default as log_cfg
 
@@ -24,10 +23,10 @@ def main():
 
     args = p.parse_args()
     load_config()
+    log_cfg.add_stdout_handler()
 
     if args.debug:
-        log_cfg.set_log_level(logging.DEBUG)
-        log_cfg.add_handler(logging.StreamHandler(stream=sys.stdout))
+        log_cfg.set_log_level(10)
 
     if args.check_all_deliveries:
         check_all_deliveries()

--- a/bin/deliver_data_to_gel.py
+++ b/bin/deliver_data_to_gel.py
@@ -13,13 +13,13 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument('--dry_run', action='store_true')
     p.add_argument('--debug', action='store_true')
-    p.add_argument('--work_dir', type=str, required=True)
+    p.add_argument('--work_dir', type=str)
     group = p.add_mutually_exclusive_group()
     group.add_argument('--sample_id', type=str)
     group.add_argument('--user_sample_id', type=str)
     p.add_argument('--force_new_delivery', action='store_true')
     p.add_argument('--no_cleanup', action='store_true')
-    p.add_argument('--check_all_md5sums', action='store_true')
+    p.add_argument('--check_all_deliveries', action='store_true')
     p.add_argument('--report', action='store_true')
 
     args = p.parse_args()
@@ -29,12 +29,12 @@ def main():
         log_cfg.set_log_level(logging.DEBUG)
         log_cfg.add_handler(logging.StreamHandler(stream=sys.stdout))
 
-    if args.check_all_md5sums:
-        check_all_deliveries(args.work_dir)
+    if args.check_all_deliveries:
+        check_all_deliveries()
     elif args.report:
         report_all()
     else:
-        gel_delivery = GelDataDelivery(args.work_dir, sample_id=args.sample_id, user_sample_id=args.user_sample_id,
+        gel_delivery = GelDataDelivery(args.sample_id, user_sample_id=args.user_sample_id, work_dir=args.work_dir,
                                        no_cleanup=args.no_cleanup, dry_run=args.dry_run, force_new_delivery=args.force_new_delivery)
         gel_delivery.deliver_data()
 

--- a/requirements_no_pdf.txt
+++ b/requirements_no_pdf.txt
@@ -1,7 +1,0 @@
-EGCG-Core>=0.7.1
-jinja2==2.8
-cached-property>=1.3.0
-matplotlib==1.5.3
-pandas==0.19.2
-numpy==1.12.0
-pyclarity-lims>=0.4

--- a/tests/test_confirm_delivery.py
+++ b/tests/test_confirm_delivery.py
@@ -210,7 +210,7 @@ class TestConfirmDelivery(TestProjectManagement):
     def test_confirm_download_in_lims(self, mocked_get_list_of_samples, mocked_get_workflow_stage,
                                       mocked_lims_connection):
         mocked_get_list_of_samples.return_value = [Mock(artifact=Mock(spec=Artifact))]
-        mocked_get_workflow_stage.return_value = Mock(step=Mock(spec=ProtocolStep, id='s1', permittedcontainers=list()))
+        mocked_get_workflow_stage.return_value = Mock(step=Mock(spec=ProtocolStep, id='s1', permitted_containers=list()))
         self.c.confirmed_samples.append('sample1')
         self.c.confirm_download_in_lims()
         mocked_get_list_of_samples.assert_called_with(sample_names=['sample1'])

--- a/tests/test_upload_to_gel/test_upload_to_gel.py
+++ b/tests/test_upload_to_gel/test_upload_to_gel.py
@@ -140,14 +140,14 @@ class TestGelDataDelivery(TestProjectManagement):
                 md5(f)
 
         self.gel_data_delivery_dry = GelDataDelivery(
-            self.staging_dir,
             'sample1',
+            work_dir=self.staging_dir,
             dry_run=True,
             no_cleanup=True
         )
         self.gel_data_delivery = GelDataDelivery(
-            self.staging_dir,
             'sample1',
+            work_dir=self.staging_dir,
             dry_run=False,
             no_cleanup=True
         )

--- a/tests/test_upload_to_gel/test_upload_to_gel.py
+++ b/tests/test_upload_to_gel/test_upload_to_gel.py
@@ -229,6 +229,6 @@ class TestGelDataDelivery(TestProjectManagement):
             self.gel_data_delivery.check_md5sum()
 
             self.gel_data_delivery.deliver_db.cursor.execute('select * from delivery;')
-            obs = self.gel_data_delivery.deliver_db.cursor.fetchall()
+            obs = self.gel_data_delivery.deliver_db.cursor.fetchall()[0]
             assert obs[6] == 'passed'  # md5_status
             assert obs[8] == 'passed'  # qc_status

--- a/upload_to_gel/deliver_data_to_gel.py
+++ b/upload_to_gel/deliver_data_to_gel.py
@@ -94,12 +94,15 @@ class DeliveryDB:
 
 
 class GelDataDelivery(AppLogger):
-    def __init__(self, work_dir, sample_id, user_sample_id=None, dry_run=False, no_cleanup=False, force_new_delivery=False):
+    def __init__(self, sample_id, user_sample_id=None, work_dir=None, dry_run=False, no_cleanup=False, force_new_delivery=False):
         self.sample_id = sample_id or self.resolve_sample_id(user_sample_id)
         self.dry_run = dry_run
         self.work_dir = work_dir
         self.no_cleanup = no_cleanup
         self.force_new_delivery = force_new_delivery
+
+        if not self.work_dir:
+            self.warning('Work dir not set - data delivery not available')
 
     @staticmethod
     def resolve_sample_id(user_sample_id):

--- a/upload_to_gel/deliver_data_to_gel.py
+++ b/upload_to_gel/deliver_data_to_gel.py
@@ -82,12 +82,12 @@ class DeliveryDB:
 
     def report_all(self):
         self.cursor.execute('SELECT * FROM delivery')
-        keys = ('id', 'sample_id', 'external_sample_id', 'creation_date', 'upload_state', 'upload_confirm_date',
+        keys = ('delivery_id', 'sample_id', 'external_sample_id', 'creation_date', 'upload_state', 'upload_confirm_date',
                 'md5_state', 'md5_confirm_date', 'qc_state', 'qc_confirm_date', 'failure_reason')
 
         print('\t'.join(keys))
         for delivery in self.cursor.fetchall():
-            print('\t'.join(str(f) for f in delivery))
+            print('\t'.join([self._delivery_number_to_id(delivery[0])] + [str(f) for f in delivery[1:]]))
 
     def __del__(self):
         self.delivery_db.close()

--- a/upload_to_gel/deliver_data_to_gel.py
+++ b/upload_to_gel/deliver_data_to_gel.py
@@ -101,9 +101,6 @@ class GelDataDelivery(AppLogger):
         self.no_cleanup = no_cleanup
         self.force_new_delivery = force_new_delivery
 
-        if not self.work_dir:
-            self.warning('Work dir not set - data delivery not available')
-
     @staticmethod
     def resolve_sample_id(user_sample_id):
         samples = clarity.connection().get_samples(udf={'User Sample Name': user_sample_id})
@@ -277,13 +274,13 @@ class GelDataDelivery(AppLogger):
             self.error('Delivery %s sample %s md5 check failed - was checked before on %s', self.delivery_id, self.sample_id, md5_confirm_date)
 
 
-def check_all_deliveries(work_dir):
+def check_all_deliveries():
     delivery_db = DeliveryDB()
-    delivery_db.cursor.execute('SELECT sample_id from delivery WHERE upload_state=? AND md5_state IS NULL', (SUCCESS_KW,))
+    delivery_db.cursor.execute('SELECT sample_id from delivery WHERE upload_state=? AND qc_state IS NULL', (SUCCESS_KW,))
     samples = delivery_db.cursor.fetchall()
     if samples:
         for sample_id, in samples:
-            dd = GelDataDelivery(work_dir, sample_id)
+            dd = GelDataDelivery(sample_id)
             dd.check_delivery_data()
 
 

--- a/upload_to_gel/deliver_data_to_gel.py
+++ b/upload_to_gel/deliver_data_to_gel.py
@@ -1,18 +1,14 @@
-import glob
 import os
-import shutil
-
-import sqlite3
-
 import re
-from cached_property import cached_property
-from egcg_core import executor, clarity
-from egcg_core import rest_communication
-from egcg_core.app_logging import AppLogger
-from egcg_core.config import cfg
-from egcg_core.constants import ELEMENT_SAMPLE_EXTERNAL_ID, ELEMENT_PROJECT_ID
+import glob
+import shutil
+import sqlite3
 from requests.exceptions import HTTPError
-
+from cached_property import cached_property
+from egcg_core import executor, clarity, rest_communication
+from egcg_core.config import cfg
+from egcg_core.app_logging import AppLogger
+from egcg_core.constants import ELEMENT_SAMPLE_EXTERNAL_ID, ELEMENT_PROJECT_ID
 from upload_to_gel.client import DeliveryAPIClient
 
 
@@ -21,11 +17,10 @@ FAILURE_KW = 'failed'
 
 
 class DeliveryDB:
-
     def __init__(self):
         self.delivery_db = sqlite3.connect(cfg.query('gel_upload', 'delivery_db'))
         self.cursor = self.delivery_db.cursor()
-        self.cursor.execute('''CREATE TABLE  IF NOT EXISTS delivery(
+        self.cursor.execute('''CREATE TABLE IF NOT EXISTS delivery(
            id INTEGER PRIMARY KEY,
            sample_id TEXT,
            external_sample_id TEXT,
@@ -33,13 +28,18 @@ class DeliveryDB:
            upload_state TEXT DEFAULT NULL,
            upload_confirm_date DATETIME DEFAULT NULL,
            md5_state TEXT DEFAULT NULL,
-           md5_confirm_date DATETIME DEFAULT NULL
+           md5_confirm_date DATETIME DEFAULT NULL,
+           qc_state TEXT DEFAULT NULL,
+           qc_confirm_date DATETIME DEFAULT NULL,
+           failure_reason TEXT DEFAULT NULL
         );''')
 
-    def _delivery_number_to_id(self, delivery_number):
+    @staticmethod
+    def _delivery_number_to_id(delivery_number):
         return 'ED%08d' % delivery_number
 
-    def _delivery_id_to_number(self, delivery_id):
+    @staticmethod
+    def _delivery_id_to_number(delivery_id):
         return int(delivery_id[2:])
 
     def create_delivery(self, sample_id, external_sample_id):
@@ -64,6 +64,9 @@ class DeliveryDB:
     def get_md5_confirmation_from(self, delivery_id):
         return self.get_info_from(delivery_id)[6:8]
 
+    def get_qc_confirmation_from(self, delivery_id):
+        return self.get_info_from(delivery_id)[8:10]
+
     def get_most_recent_delivery_id(self, sample_id):
         q = 'SELECT id from delivery WHERE sample_id=? ORDER BY creation_date DESC LIMIT 1;'
         self.cursor.execute(q, (sample_id,))
@@ -82,14 +85,18 @@ class DeliveryDB:
         self.cursor.execute(q, (state, self._delivery_id_to_number(delivery_id)))
         self.delivery_db.commit()
 
+    def set_qc_state(self, delivery_id, state):
+        q = 'UPDATE delivery SET qc_state = ?, qc_confirm_date = datetime("now") WHERE id = ?;'
+        self.cursor.execute(q, (state, self._delivery_id_to_number(delivery_id)))
+        self.delivery_db.commit()
+
     def __del__(self):
         self.delivery_db.close()
 
+
 class GelDataDelivery(AppLogger):
     def __init__(self, work_dir, sample_id, user_sample_id=None, dry_run=False, no_cleanup=False, force_new_delivery=False):
-        self.sample_id = sample_id
-        if not self.sample_id:
-            self.sample_id = self.resolve_sample_id(user_sample_id)
+        self.sample_id = sample_id or self.resolve_sample_id(user_sample_id)
         self.dry_run = dry_run
         self.work_dir = work_dir
         self.no_cleanup = no_cleanup
@@ -136,7 +143,6 @@ class GelDataDelivery(AppLogger):
         lims_sample = clarity.get_sample(self.sample_id)
         return lims_sample.udf.get('2D Barcode')
 
-
     @cached_property
     def sample_delivery_folder(self):
         delivery_dest = cfg.query('delivery', 'dest')
@@ -155,13 +161,12 @@ class GelDataDelivery(AppLogger):
         eid = self.sample_data[ELEMENT_SAMPLE_EXTERNAL_ID]
         m = re.match('[0-9]{9}_[0-9A-Za-z]{7}_[0-9]{4}_[0-9A-Za-z]{10}', eid)
         if not m:
-            self.error('%s does not match the require regex', eid)
+            self.error('%s does not match the required regex', eid)
         return eid
 
     @property
     def external_id(self):
         return self.sample_data[ELEMENT_SAMPLE_EXTERNAL_ID]
-
 
     def cleanup(self):
         if self.no_cleanup:
@@ -170,29 +175,25 @@ class GelDataDelivery(AppLogger):
             shutil.rmtree(self.staging_dir)
 
     def link_fastq_files(self, fastq_path):
-        source1 = os.path.join(self.sample_delivery_folder, self.external_id + '_R1.fastq.gz')
-        source2 = os.path.join(self.sample_delivery_folder, self.external_id + '_R2.fastq.gz')
-        if not os.path.isfile(source1):
-            raise FileNotFoundError(source1 + ' does not exists')
-        if not os.path.isfile(source2):
-            raise FileNotFoundError(source2 + ' does not exists')
-        os.symlink(source1, os.path.join(fastq_path, self.sample_barcode + '_R1.fastq.gz'))
-        os.symlink(source2, os.path.join(fastq_path, self.sample_barcode + '_R2.fastq.gz'))
+        for i in (1, 2):
+            source = os.path.join(self.sample_delivery_folder, self.external_id + '_R%s.fastq.gz' % i)
+            if not os.path.isfile(source):
+                raise FileNotFoundError(source + ' does not exists')
+            os.symlink(source, os.path.join(fastq_path, self.sample_barcode + '_R%s.fastq.gz' % i))
 
     def create_md5sum_txt(self, sample_path):
-        with open(os.path.join(self.sample_delivery_folder, self.external_id + '_R1.fastq.gz.md5')) as fh:
-            md5_1, fp = fh.readline().strip().split()
-        with open(os.path.join(self.sample_delivery_folder, self.external_id + '_R2.fastq.gz.md5')) as fh:
-            md5_2, fp = fh.readline().strip().split()
-        with open(os.path.join(sample_path,'md5sum.txt'), 'w') as fh:
-            fh.write('%s %s\n' % (md5_1, 'fastq/' + self.sample_barcode + '_R1.fastq.gz'))
-            fh.write('%s %s\n' % (md5_2, 'fastq/' + self.sample_barcode + '_R2.fastq.gz'))
+        with open(os.path.join(sample_path, 'md5sum.txt'), 'w') as fh:
+            for i in (1, 2):
+                with open(os.path.join(self.sample_delivery_folder, self.external_id + '_R%s.fastq.gz.md5' % i)) as f:
+                    md5, fp = f.readline().strip().split()
+                    fh.write('%s %s\n' % (md5, 'fastq/' + self.sample_barcode + '_R%s.fastq.gz' % i))
 
-    def rsync_to_destination(self, delivery_id_path):
+    @staticmethod
+    def rsync_to_destination(delivery_id_path):
         options = ['-rv', '-L', '--timeout=300', '--append', '--partial', '--chmod ug+rwx,o-rwx', '--perms']
         ssh_options = ['ssh', '-o StrictHostKeyChecking=no', '-o TCPKeepAlive=yes', '-o ServerAliveInterval=100',
                        '-o KeepAlive=yes', '-o BatchMode=yes', '-o LogLevel=Error',
-                       '-i %s'%cfg.query('gel_upload', 'ssh_key'), '-p 22']
+                       '-i %s' % cfg.query('gel_upload', 'ssh_key'), '-p 22']
         destination = '%s@%s:%s' % (cfg.query('gel_upload', 'username'), cfg.query('gel_upload', 'host'), cfg.query('gel_upload', 'dest'))
 
         cmd = ' '.join(['rsync',  ' '.join(options), '-e "%s"' % ' '.join(ssh_options), delivery_id_path, destination])
@@ -200,14 +201,15 @@ class GelDataDelivery(AppLogger):
 
     def try_rsync(self, delivery_id_path, max_nb_tries=3):
         tries = 1
-        while tries < max_nb_tries:
+        exit_code = 9
+        while tries <= max_nb_tries:
             exit_code = self.rsync_to_destination(delivery_id_path)
             if exit_code == 0:
                 return exit_code
             tries += 1
         return exit_code
 
-    def delivery_id_exist(self):
+    def delivery_id_exists(self):
         try:
             send_action_to_rest_api(action='get', delivery_id=self.delivery_id)
             return True
@@ -225,10 +227,10 @@ class GelDataDelivery(AppLogger):
         self.create_md5sum_txt(sample_path)
 
         if not self.dry_run:
-            if not self.delivery_id_exist():
+            if not self.delivery_id_exists():
                 send_action_to_rest_api(action='create', delivery_id=self.delivery_id, sample_id=self.sample_barcode)
             exit_code = self.try_rsync(delivery_id_path)
-            self.info('Rsync exit code is %s' % exit_code)
+            self.info('Rsync exit code is %s', exit_code)
             if exit_code == 0:
                 self.deliver_db.set_upload_state(self.delivery_id, SUCCESS_KW)
                 send_action_to_rest_api(action='delivered', delivery_id=self.delivery_id, sample_id=self.sample_barcode)
@@ -238,45 +240,61 @@ class GelDataDelivery(AppLogger):
                     action='upload_failed',
                     delivery_id=self.delivery_id,
                     sample_id=self.sample_barcode,
-                    failure_reason='rsync returned %s exit code' % (exit_code)
+                    failure_reason='rsync returned %s exit code' % exit_code
                 )
         else:
-            self.info('Create delivery id %s from sample_id=%s' % (self.delivery_id, self.sample_id,))
-            self.info('Create delivery plateform sample_barcode=%s' % (self.sample_barcode,))
+            self.info('Create delivery id %s from sample_id=%s', self.delivery_id, self.sample_id)
+            self.info('Create delivery platform sample_barcode=%s', self.sample_barcode)
             self.info('Run rsync')
         self.cleanup()
 
     def check_md5sum(self):
         info = self.deliver_db.get_info_from(self.delivery_id)
-        id, sample_id, external_sample_id, creation_date, upload_state, upload_confirm_date, md5_state, md5_confirm_date = info
-        if upload_state == SUCCESS_KW and not md5_confirm_date:
-            req = send_action_to_rest_api(action='get', delivery_id= self.delivery_id)
-            sample_json = req.json()
-            if sample_json['state'] == "md5_passed":
+        _id, sample_id, external_sample_id, creation_date, upload_state, upload_confirm_date, md5_state, md5_confirm_date, qc_state, qc_confirm_date, failure_reason = info
+        if upload_state == SUCCESS_KW and not all((md5_confirm_date, qc_confirm_date)):
+            sample = send_action_to_rest_api(action='get', delivery_id=self.delivery_id).json()
+            param, status = sample['state'].split('_')  # md5_passed -> ('md5', 'passed')
+            if param == 'md5':
+                self.deliver_db.set_md5_state(self.delivery_id, status)
+            elif param == 'qc':
                 self.deliver_db.set_md5_state(self.delivery_id, SUCCESS_KW)
-                self.info('Delivery %s sample %s: md5 check has been successful', self.delivery_id, self.sample_id)
-            elif sample_json['state'] == "md5_failed":
-                self.deliver_db.set_md5_state(self.delivery_id, FAILURE_KW)
-                self.info('Delivery %s sample %s: md5 check has failed', self.delivery_id, self.sample_id)
+                self.deliver_db.set_qc_state(self.delivery_id, status)
+
+            self.info('Delivery %s sample %s %s check: %s', self.delivery_id, self.sample_id, param, status)
+
         elif not upload_state:
             self.error('Delivery %s sample %s: Has not been uploaded', self.delivery_id, self.sample_id)
         elif upload_state == FAILURE_KW:
-            self.error('Delivery %s sample %s: Uploaded has failed', self.delivery_id, self.sample_id)
+            self.error('Delivery %s sample %s: Upload failed', self.delivery_id, self.sample_id)
+        elif qc_state:
+            self.error('Delivery %s sample %s qc check failed - was checked before on %s', self.delivery_id, self.sample_id, qc_confirm_date)
         elif md5_state:
-            self.error('Delivery %s sample %s md5 check failed was checked before on ', self.delivery_id, self.sample_id, md5_confirm_date)
+            self.error('Delivery %s sample %s md5 check failed - was checked before on %s', self.delivery_id, self.sample_id, md5_confirm_date)
 
 
 def check_all_md5sums(work_dir):
     delivery_db = DeliveryDB()
-    delivery_db.cursor.execute('SELECT sample_id from delivery WHERE upload_state=? AND md5_state IS NULL', (SUCCESS_KW, ))
+    delivery_db.cursor.execute('SELECT sample_id from delivery WHERE upload_state=? AND md5_state IS NULL', (SUCCESS_KW,))
     samples = delivery_db.cursor.fetchall()
     if samples:
         for sample_id, in samples:
             dd = GelDataDelivery(work_dir, sample_id)
             dd.check_md5sum()
 
+
+def report_all():
+    delivery_db = DeliveryDB()
+    delivery_db.cursor.execute('SELECT * FROM delivery')
+    keys = ('id', 'sample_id', 'external_sample_id', 'creation_date', 'upload_state', 'upload_confirm_date',
+            'md5_state', 'md5_confirm_date', 'qc_state', 'qc_confirm_date', 'failure_reason')
+
+    print('\t'.join(keys))
+    for s in delivery_db.cursor.fetchall():
+        print('\t'.join(s))
+
+
 def send_action_to_rest_api(action, **kwargs):
-    api_param = cfg.query('gel_upload', 'rest_api')
+    api_param = cfg['gel_upload']['rest_api']
     # host, user, pswd from config
     api_param['action'] = action
     api_param.update(kwargs)


### PR DESCRIPTION
- Adds a reporting feature to gel_upload to view all sample deliveries.
- Adds new checks and SQLite fields for GeL-side qc checks and failure reasons.

A pre-existing database can be updated with:
```sql
ALTER TABLE delivery ADD COLUMN qc_state TEXT DEFAULT NULL;
ALTER TABLE delivery ADD COLUMN qc_confirm_date TEXT DEFAULT NULL;
ALTER TABLE delivery ADD COLUMN failure_reason TEXT DEFAULT NULL;
```

Closes #43