### PR TITLE
Deletion notifications and production fixes

### DIFF
--- a/data_deletion/__init__.py
+++ b/data_deletion/__init__.py
@@ -1,8 +1,10 @@
+import sys
+import traceback
 from os import listdir, stat
 from os.path import join, isdir
 from datetime import datetime
 from cached_property import cached_property
-from egcg_core import app_logging, executor, clarity, rest_communication, util
+from egcg_core import app_logging, executor, clarity, rest_communication, util, notifications
 from egcg_core.app_logging import AppLogger
 from egcg_core.archive_management import is_archived, ArchivingError
 from egcg_core.config import cfg
@@ -40,6 +42,7 @@ class Deleter(app_logging.AppLogger):
         self.work_dir = work_dir
         self.dry_run = dry_run
         self.deletion_limit = deletion_limit
+        self.ntf = notifications.NotificationCentre('%s at %s' % (self.__class__.__name__, self._strnow()))
 
     @cached_property
     def deletion_dir(self):  # need caching because of reference to datetime.now
@@ -73,6 +76,25 @@ class Deleter(app_logging.AppLogger):
     @classmethod
     def _strnow(cls):
         return cls._now().strftime('%d_%m_%Y_%H:%M:%S')
+
+    def delete_data(self):
+        """
+        The main behaviour of the Deleter
+        :return: None
+        """
+        raise NotImplementedError
+
+    def run(self):
+        """Runs self.delete_data with exception handling and notifications."""
+        try:
+            self.delete_data()
+        except Exception as e:
+            etype, value, tb = sys.exc_info()
+            stacktrace = ''.join(traceback.format_exception(etype, value, tb))
+            self.critical('Encountered a %s exception: %s. Stacktrace below:\n%s', e.__class__.__name__, e, stacktrace)
+            self.ntf.notify_all(stacktrace)
+            executor.stop_running_jobs()
+            sys.exit(9)
 
 
 class ProcessedSample(AppLogger):

--- a/data_deletion/client.py
+++ b/data_deletion/client.py
@@ -40,7 +40,7 @@ def main(argv=None):
     deleter_args = {k: v for k, v in args.__dict__.items() if v}
 
     d = deleters[deleter_type](**deleter_args)
-    d.delete_data()
+    d.run()
 
 
 if __name__ == '__main__':

--- a/data_deletion/delivered_data.py
+++ b/data_deletion/delivered_data.py
@@ -148,7 +148,7 @@ class DeliveredDataDeleter(Deleter):
         self.debug('Found %s samples for deletion: %s' % (len(deletable_samples), sample_ids))
         self.setup_samples_for_deletion(deletable_samples, self.dry_run)
 
-        if not self.deletable_samples or self.dry_run:
+        if not deletable_samples or self.dry_run:
             return 0
 
         for s in deletable_samples:

--- a/etc/example_data_deletion.yaml
+++ b/etc/example_data_deletion.yaml
@@ -14,4 +14,6 @@ default:
             recipients: [recipient@email.com]
         log_dir: tests/assets/data_deletion/logs
 
-
+    notifications:
+        log:
+            log_file: tests/assets/data_deletion/notifications.log

--- a/etc/example_data_deletion.yaml
+++ b/etc/example_data_deletion.yaml
@@ -16,4 +16,4 @@ default:
 
     notifications:
         log:
-            log_file: tests/assets/data_deletion/notifications.log
+            log_file: tests/assets/notifications.log

--- a/etc/example_data_delivery.yaml
+++ b/etc/example_data_delivery.yaml
@@ -9,8 +9,8 @@ default:
     delivery:
         source: tests/assets/data_delivery/source
         dest: tests/assets/data_delivery/dest
-        clarity_workflow_name: 'Data Release'
-        clarity_stage_name: 'Data Release'
+        clarity_workflow_name: 'Data Release workflow'
+        clarity_stage_name: 'Data Release stage'
         email_notification:
             mailhost: smtp.test.me
             port: 25

--- a/tests/test_data_deletion/__init__.py
+++ b/tests/test_data_deletion/__init__.py
@@ -33,3 +33,11 @@ class TestDeleter(TestProjectManagement):
             os.remove(deletion_script)
         for tmpdir in find_files(self.assets_deletion, '*', '.data_deletion_*'):
             rmtree(tmpdir)
+
+    @patch('egcg_core.notifications.log.LogNotification.notify')
+    def test_crash_report(self, mocked_notify):
+        patched_delete = patch.object(self.deleter.__class__, 'delete_data', side_effect=ValueError('Something broke'))
+        with patch('sys.exit'), patched_delete:
+            self.deleter.run()
+
+        assert 'ValueError: Something broke' in mocked_notify.call_args[0][0]

--- a/tests/test_data_delivery/test_data_delivery.py
+++ b/tests/test_data_delivery/test_data_delivery.py
@@ -153,11 +153,11 @@ for process in sample_templates:
 
 
 def fake_get_document(*args, **kwargs):
-    match = list(kwargs.values())[0]
+    match = kwargs.get('where') or kwargs['match']
     if 'sample_id' in match:
-        return rest_responses.get(args[0], {}).get(match.get('sample_id'))
+        return rest_responses.get(args[0], {}).get(match['sample_id'])
     if 'project_id' in match:
-        return [rr for rr in rest_responses.get(args[0], {}).values() if rr['project_id'] == match.get('project_id')]
+        return [rr for rr in rest_responses.get(args[0], {}).values() if rr['project_id'] == match['project_id']]
 
 
 patch_get_document = patch('egcg_core.rest_communication.get_document', side_effect=fake_get_document)

--- a/tests/test_data_delivery/test_data_delivery.py
+++ b/tests/test_data_delivery/test_data_delivery.py
@@ -283,7 +283,7 @@ class TestDataDelivery(TestProjectManagement):
         delivered_date = datetime.datetime(2018, 1, 10)
         with patch('bin.deliver_reviewed_data._now', return_value=delivered_date), \
                 patch('egcg_core.rest_communication.patch_entry') as mpatch, \
-                patch('egcg_core.clarity.route_samples_to_delivery_workflow') as mroute:
+                patch('egcg_core.clarity.route_samples_to_workflow_stage') as mroute:
             self.delivery_real_merged.samples2list_files = {
                 'p1sample1': [{'file_path': 'path to file1'}],
                 'p1sample2': [{'file_path': 'path to file2'}],
@@ -307,7 +307,11 @@ class TestDataDelivery(TestProjectManagement):
                 },
                 update_lists=['files_delivered']
             )
-            mroute.assert_called_with(['p1sample1', 'p1sample2'])
+            mroute.assert_called_with(
+                ['p1sample1', 'p1sample2'],
+                'Data Release workflow',
+                stage_name='Data Release stage'
+            )
 
     def test_get_deliverable_projects_samples(self):
         with patch_process, patch_get_document, patch_get_documents:


### PR DESCRIPTION
- Adding crash reporting to data deletion - closes #57
- Making workflow/stage names configurable for delivery routing - closes #59
- Fetching all pages in `DataDelivery.already_delivered_samples` - closes #58
- Fixing bug where empty deletable samples would not stop execution in `DeliveredDataDeleter.delete_data`
