### PR TITLE
Genome downloader rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 install:
   - "pip install -r requirements.txt"
   - "pip install python-coveralls pytest-cov"
+  - "pip install coverage --upgrade"
 script: py.test tests/ -v --cov bin --cov data_deletion --cov project_report --cov upload_to_gel --cov-report term-missing
 after_success:
   - coveralls

--- a/bin/reference_data.py
+++ b/bin/reference_data.py
@@ -1,142 +1,304 @@
 import os
+import ftplib
 import requests
 import argparse
-import ftplib
-import yaml
+import subprocess
 from datetime import datetime
+from cached_property import cached_property
+from egcg_core import util, rest_communication
 from egcg_core.config import cfg
-from egcg_core.app_logging import logging_default as log_cfg
+from egcg_core.app_logging import AppLogger, logging_default
+from egcg_core.executor import local_execute
 from config import load_config
 
-log_cfg.add_stdout_handler()
-app_logger = log_cfg.get_logger('genome_downloader')
+
+logging_default.set_log_level(10)
+logging_default.add_stdout_handler()
 
 
-def _now():
-    return datetime.now().strftime('%d/%m/%Y %H:%M:%S')
+class DownloadError(Exception):
+    pass
 
 
-def _query_ncbi(eutil, db, **query_args):
-    url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/' + eutil + '.fcgi'
-    params = {'db': db, 'retmode': 'JSON', 'version': '2.0'}
-    params.update(query_args)
-    return requests.get(url, params).json()
+def now():
+    return datetime.utcnow().strftime('%d_%m_%Y_%H:%M:%S')
 
 
-def list_ids(db, search_term, retmax=20):
-    ids = _query_ncbi('esearch', db, term=search_term, retmax=retmax)['esearchresult']
-    if int(ids['count']) > retmax:
-        app_logger.warning('More than %s results found - try a higher retmax, or narrow the search term', retmax)
+class Downloader(AppLogger):
+    def __init__(self, species, genome_version=None, upload=True, download=True):
+        self.species = species
+        self.ftp_species = species.lower().replace(' ', '_')
+        self.species_dir = self.ftp_species[0].upper() + self.ftp_species[1:]
+        self.genome_version = genome_version or self.latest_genome_version()
+        self.upload = upload
+        self.download = download
 
-    app_logger.info('Found %s ids in %s database for %s', ids['count'], db, search_term)
-    return ids['idlist']
+        self.data_dir = os.path.join(
+            cfg['genome_downloader']['base_dir'],
+            self.species_dir,
+            self.genome_version
+        )
+        self.tools = {t: cfg['genome_downloader'][t] for t in ('picard', 'gatk', 'samtools')}
+        self.info('Data dir: %s', self.data_dir)
 
+    def run(self):
+        if self.ensembl_release:  # and not self.manual:
+            if self.download:
+                self.download_data()
+                self.prepare_data()
 
-def list_reference_genomes(search_term):
-    genome_ids = [str(i) for i in list_ids('assembly', search_term)]
-    genome_summaries = _query_ncbi('esummary', 'assembly', id=','.join(genome_ids))['result']
-    genome_summaries.pop('uids')
-    for v in genome_summaries.values():
-        print(
-            '{id} {name}, species {species} ({taxid}), released {date}, ftp={ftp_path}'.format(
-                id=v['uid'], name=v['assemblyname'], species=v['speciesname'], taxid=v['speciestaxid'],
-                date=v['seqreleasedate'], ftp_path=v.get('ftppath_genbank') or '(no ftp available)'
+            payload = self.prepare_ensembl_metadata()
+        else:
+            self.info('Running metadata upload only')
+            assert self.genome_version
+            payload = self.prepare_manual_metadata()
+
+        self.finish_metadata(payload)
+
+    @cached_property
+    def ftp(self):
+        ftp = ftplib.FTP('ftp.ensembl.org')
+        ftp.login()
+        ftp.cwd('pub')
+        return ftp
+
+    @cached_property
+    def all_ensembl_releases(self):
+        releases = [
+            d for d in self.ftp.nlst()  # Ensembl doesn't support mlsd for some reason
+            if d.startswith('release-')
+        ]
+        releases.reverse()
+        return releases
+
+    @cached_property
+    def ensembl_release(self):
+        for release in self.all_ensembl_releases:
+            ls = self.ftp.nlst('%s/fasta/%s/dna' % (release, self.ftp_species))
+            top_level_fastas = [f for f in ls if f.endswith('dna.toplevel.fa.gz')]
+            if top_level_fastas and self.genome_version in top_level_fastas[0]:
+                return release
+
+        self.info('Could not find any Ensembl releases for ' + self.genome_version)
+
+    def latest_genome_version(self):
+        ls = self.ftp.nlst('%s/fasta/%s/dna' % (self.all_ensembl_releases[0], self.ftp_species))
+        if not ls:
+            raise DownloadError('Could not find %s in latest Ensembl release' % self.ftp_species)
+
+        ext = '.dna.toplevel.fa.gz'
+        top_level_fasta = [f for f in ls if f.endswith(ext)][0]
+        return '.'.join(top_level_fasta.split('.')[1:]).replace(ext, '')
+
+    def download_data(self):
+        self.info('Downloading reference genome')
+        base_dir = '%s/fasta/%s' % (self.ensembl_release, self.ftp_species)
+
+        ls = self.ftp.nlst(base_dir)
+        if 'dna_index' in ls:
+            ls = self.ftp.nlst(os.path.join(base_dir, 'dna_index'))
+        else:
+            ls = self.ftp.nlst(os.path.join(base_dir, 'dna'))
+
+        files_to_download = [f for f in ls if 'dna.toplevel' in f]
+        self.info('Reference genome: found %i files, downloading %i', len(ls), len(files_to_download))
+        for f in files_to_download:
+            self.download_file(f)
+
+        ls = self.ftp.nlst('%s/variation/vcf/%s' % (self.ensembl_release, self.ftp_species))
+        files_to_download = [f for f in ls if '%s.vcf.gz' % self.ftp_species in f.lower()]
+        if not files_to_download:
+            i = input('%i files found. Enter a basename for a single VCF to use, or nothing to continue without '
+                      'variants. ' % len(ls))
+            if i:
+                files_to_download = [f for f in ls if i in f]  # this should include the index file
+            else:
+                files_to_download = []
+
+        self.info('Variation: found %i files, downloading %i', len(ls), len(files_to_download))
+        for f in files_to_download:
+            self.download_file(f)
+
+    def download_file(self, fp):
+        local_file_path = os.path.join(self.data_dir, os.path.basename(fp))
+        dir_name = os.path.dirname(local_file_path)
+        if not os.path.isdir(dir_name):
+            os.makedirs(dir_name)
+
+        with open(local_file_path, 'wb') as f:
+            self.ftp.retrbinary('RETR ' + fp, f.write)
+
+    def prepare_data(self):
+        self.info('Preparing downloaded data')
+        fa_gzs = util.find_files(self.data_dir, '*dna.toplevel.fa.gz')
+        if len(fa_gzs) != 1:
+            raise DownloadError('%s fa.gz files found' % len(fa_gzs))
+
+        fastas = util.find_files(self.data_dir, '*dna.toplevel.fa')
+        if fastas:
+            raise DownloadError('Unexpected .fa files found: %s' % fastas)
+
+        fasta_gz = fa_gzs[0]
+        local_execute('gzip -d %s' % fasta_gz).join()
+        fasta = util.find_file(self.data_dir, '*dna.toplevel.fa')
+        if not util.find_files(self.data_dir, '*dna.toplevel.fa.gz.fai'):
+            local_execute(self.tools['samtools'] + ' faidx %s' % fasta).join()
+
+        dict_file = os.path.splitext(fasta)[0] + '.dict'
+        if not util.find_file(dict_file):
+            local_execute(self.tools['picard'] + ' CreateSequenceDictionary R=%s O=%s' % (fasta, dict_file)).join()
+
+        vcfs = util.find_files(self.data_dir, '*.vcf.gz')
+        if len(vcfs) == 1:
+            vcf = vcfs[0]
+        else:
+            vcf = None
+
+        if not vcf:
+            self.info('Finishing with fasta reference genome only')
+        else:
+            assert os.path.isfile(vcf)
+            validation_log = '%s.validate_variants.log' % vcf
+            p = subprocess.Popen(
+                'java -jar %s -T ValidateVariants -V %s -R %s -warnOnErrors > %s 2>&1' % (
+                    self.tools['gatk'], vcf, fasta, validation_log
+                ),
+                shell=True
             )
+            exit_status = p.wait()
+            self.info('Validation completed with exit status %s - see log at %s', exit_status, validation_log)
+
+    def prepare_ensembl_metadata(self):
+        payload = {
+            'tools_used': {
+                'picard': subprocess.Popen(  # picard --version gives exit status 1, so need to use Popen
+                    [self.tools['picard'], 'CreateSequenceDictionary', '--version'],
+                    stderr=subprocess.PIPE
+                ).communicate()[1].decode().strip(),
+                'samtools': subprocess.check_output(
+                    [self.tools['samtools'], '--version']
+                ).decode().split('\n')[0].split(' ')[1],
+                'gatk': subprocess.check_output(['java', '-jar', self.tools['gatk'], '--version']).decode().strip()
+            },
+            'data_source': 'ftp://ftp.ensembl.org/pub/' + self.ensembl_release
+        }
+        assembly_data = requests.get(
+            'http://rest.ensembl.org/info/assembly/%s' % self.species,
+            params={'content-type': 'application/json'}
+        ).json()
+        if self.genome_version in assembly_data['assembly_name']:
+            payload['chromosome_count'] = len(assembly_data['karyotype'])
+            payload['genome_size'] = assembly_data['base_pairs']
+        else:
+            self.info('Assembly not found in Ensembl Rest API')
+            for field in ('chromosome_count', 'genome_size'):
+                data = input('Enter a value to use for %s. ' % field)
+                if data:
+                    payload[field] = int(data)
+
+        return payload
+
+    @staticmethod
+    def prepare_manual_metadata():
+        payload = {}
+        for field in ('chromosome_count', 'genome_size'):
+            value = input('Enter a value to use for %s. ' % field)
+            if value:
+                payload[field] = int(value)
+
+        data_source = input('Enter a value to use for data_source')
+        if data_source:
+            payload['data_source'] = data_source
+
+        payload['tools_used'] = {}
+        tools = input("Enter tools used to index/validate data in the format 'tool_1:version,tool_2:version...' ")
+        for t in tools.split(','):
+            tool, version = t.split(':')
+            payload['tools_used'][tool] = version
+
+        return payload
+
+    def finish_metadata(self, payload):
+        payload.update(
+            assembly_name=self.genome_version,
+            species=self.species,
+            date_added=now()
         )
 
+        project_whitelist = input('Enter a comma-separated list of projects to whitelist for this genome. ')
+        if project_whitelist:
+            payload['project_whitelist'] = project_whitelist.split(',')
 
-def record_reference_data(species, assembly, metadata):
-    """
-    Write metadata to a file in reference_data/species/metadata.yaml.
-    :param str species:
-    :param str assembly: The genome assembly to write to, or 'dbsnp'
-    :param dict metadata:
-    """
-    md_dir = os.path.join(cfg['genome_downloader']['base_dir'], species.replace(' ', '_'))
-    os.makedirs(md_dir, exist_ok=True)
-    md_file = os.path.join(md_dir, 'metadata.yaml')
+        comments = input('Enter any comments about the genome. ')
+        if comments:
+            payload['comments'] = comments
 
-    content = {}
-    if os.path.isfile(md_file):
-        with open(md_file, 'r') as f:
-            content = yaml.safe_load(f)
+        analyses = ['qc']
+        if util.find_files(self.data_dir, '*.vcf.gz'):
+            analyses.append('variant_calling')
+            if self.ftp_species == 'homo_sapiens':  # human
+                analyses.append('bcbio')
 
-    if assembly in content:
-        app_logger.warning('%s already in metadata file. Remove this to re-run', assembly)
-        return 0
+        payload['analyses_supported'] = analyses
 
-    now = _now()
-    metadata['date_downloaded'] = now
-    content[assembly] = metadata
+        if not self.upload:
+            print(payload)
+            return
 
-    with open(md_file, 'w') as f:
-        f.write('# metadata for %s, last modified %s\n' % (species, now))
-        yaml.safe_dump(content, f, indent=4, default_flow_style=False)
+        rest_communication.post_or_patch('genomes', payload, id_field='assembly_name')
 
+        species = rest_communication.get_document('species', where={'name': self.species})
+        if species:
+            species_payload = {'genomes': [self.genome_version]}
+            if input("Enter 'y' if the current genome version should be set as the default for this species. ") == 'y':
+                species_payload['default_version'] = self.genome_version
 
-def get_reference_genome(uid):
-    data = _query_ncbi('esummary', 'assembly', id=uid)['result'][uid]
-    app_logger.info('Download Fasta files from %s, merge and index with bwa and bowtie', data['ftppath_genbank'])
+            rest_communication.patch_entry(
+                'species',
+                species_payload,
+                'name',
+                self.species,
+                update_lists=True
+            )
+        else:
+            r = requests.get(
+                'http://rest.ensembl.org/taxonomy/name/%s' % self.species,
+                params={'content-type': 'application/json'}
+            )
+            taxonomy_data = r.json()
+            if r.status_code == 200 and len(taxonomy_data) == 1:
+                taxid = taxonomy_data[0]['id']
+            else:
+                taxid = input('%i taxons found for %s - enter the taxid of this species. ' % (len(taxonomy_data), self.species))
 
-    keys = ('organism', 'assemblyname', 'seqreleasedate', 'speciestaxid', 'uid', 'ftppath_genbank')
-    record_reference_data(
-        data['speciesname'],
-        data['assemblyname'],
-        {k: data[k] for k in keys}
-    )
-
-
-def list_taxids(search_term):
-    ids = list_ids('taxonomy', search_term)
-    app_logger.info('Found %s taxids for search term %s: %s', len(ids), search_term, ids)
-
-
-def get_dbsnp(taxid):
-    host = 'ftp.ncbi.nlm.nih.gov'
-    ftp = ftplib.FTP(host)
-    ftp.login()
-    wd = 'snp/organisms/'
-
-    dname = None
-    dbsnp_entries = dict(ftp.mlsd(wd))
-    for d in dbsnp_entries:
-        if d.endswith(taxid):
-            dname = d
-            break
-
-    ls = dict(ftp.mlsd(wd + dname))
-    ftp.quit()
-    if 'VCF' not in ls:
-        app_logger.warning('No vcfs found for %s', dname)
-        return 1
-
-    vcf_path = 'ftp://' + host + '/' + wd + dname + '/VCF'
-    app_logger.info('Found dbsnp vcfs for %s at %s', dname, vcf_path)
-
-    esummary = _query_ncbi('esummary', 'taxonomy', id=taxid)['result'][taxid]
-    record_reference_data(esummary['scientificname'], 'dbsnp', {'ftp': vcf_path, 'taxid': taxid})
+            rest_communication.post_entry(
+                'species',
+                {
+                    'name': self.species,
+                    'genomes': [self.genome_version],
+                    'default_version': self.genome_version,
+                    'taxid': taxid
+                }
+            )
 
 
-def main(argv=None):
-    load_config()
+def main():
     a = argparse.ArgumentParser()
-    a.add_argument('action', choices=('list', 'info'))
-    a.add_argument('type', choices=('genome', 'dbsnp'))
-    a.add_argument('--search_term', required=True)
+    a.add_argument(
+        'species',
+        help="Species name as used by Ensembl's FTP site, with underscores and lower case, e.g. 'felis_catus'"
+    )
+    a.add_argument('--genome_version', default=None)
+    a.add_argument('--no_upload', dest='upload', action='store_false', help='Turn off the metadata upload')
+    a.add_argument('--no_download', dest='download', action='store_false', help='Turn off the data download')
+    args = a.parse_args()
+    load_config()
+    d = Downloader(args.species, args.genome_version, args.upload, args.download)
+    d.run()
 
-    args = a.parse_args(argv)
 
-    if args.action == 'list' and args.type == 'genome':
-        list_reference_genomes(args.search_term)
+if __name__ == '__main__':
+    main()
 
-    elif args.action == 'list' and args.type == 'dbsnp':
-        list_taxids(args.search_term)
 
-    elif args.action == 'info' and args.type == 'genome':
-        get_reference_genome(args.search_term)
-
-    elif args.action == 'info' and args.type == 'dbsnp':
-        get_dbsnp(args.search_term)
-
-    else:
-        return 1
+# TODO: goldenpath

--- a/etc/example_project_management.yaml
+++ b/etc/example_project_management.yaml
@@ -37,10 +37,13 @@ clarity:
     username: testuser
     password: password
 
-genome_downloader:
+reference_data:
     base_dir: path/to/reference_data
-    picard: path/to/picard
+    bwa: path/to/bwa
     gatk: path/to/gatk
+    bgzip: path/to/bgzip
+    tabix: path/to/tabix
+    picard: path/to/picard
     samtools: path/to/samtools
 
 species:

--- a/etc/example_project_management.yaml
+++ b/etc/example_project_management.yaml
@@ -39,6 +39,9 @@ clarity:
 
 genome_downloader:
     base_dir: path/to/reference_data
+    picard: path/to/picard
+    gatk: path/to/gatk
+    samtools: path/to/samtools
 
 species:
     Homo sapiens:

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock, patch
-from bin import reference_data_download
+from bin import reference_data
 from tests import TestProjectManagement
 
 
@@ -12,7 +12,7 @@ def fake_check_output(argv):
 
 class TestDownloader(TestProjectManagement):
     def setUp(self):
-        self.downloader = reference_data_download.Downloader('A species', 'a_genome')
+        self.downloader = reference_data.Downloader('A species', 'a_genome')
         self.downloader.__dict__['ftp'] = Mock()
         self.downloader.__dict__['_logger'] = Mock()
 
@@ -28,7 +28,7 @@ class TestDownloader(TestProjectManagement):
         assert self.downloader.latest_genome_version() == 'a_genome'
         self.downloader.ftp.nlst.assert_called_with('a_release/fasta/a_species/dna')
 
-    @patch.object(reference_data_download.Downloader, 'download_file')
+    @patch.object(reference_data.Downloader, 'download_file')
     def test_download_data(self, mocked_download):
         files = [
             'release-1/fasta/a_species/A_species.a_genome.dna.toplevel.fa.gz',
@@ -49,7 +49,7 @@ class TestDownloader(TestProjectManagement):
 
     @patch('os.path.isfile', return_value=True)
     @patch('subprocess.Popen')
-    @patch('bin.reference_data_download.local_execute')
+    @patch('bin.reference_data.local_execute')
     @patch('egcg_core.util.find_file')
     @patch('egcg_core.util.find_files')
     def test_prepare_data(self, mocked_find_files, mocked_find_file, mocked_execute, mocked_popen, mocked_isfile):
@@ -109,7 +109,7 @@ class TestDownloader(TestProjectManagement):
     @patch('egcg_core.rest_communication.patch_entry')
     @patch('egcg_core.rest_communication.post_or_patch')
     @patch('egcg_core.util.find_files')
-    @patch('bin.reference_data_download.now', return_value='now')
+    @patch('bin.reference_data.now', return_value='now')
     @patch('builtins.input', side_effect=['project1,project2', 'Some comments', 'y', 'project1,project2', 'Some comments'])
     def test_finish_metadata(self, minput, mnow, m_find, mpostpatch, mpatch, mpost, mgetdoc, mget):
         self.downloader.finish_metadata({})


### PR DESCRIPTION
Rewrite of reference_data to download from Ensembl:

- using data from Ensembl FTP site/API
- fetches fasta data from `<release>/fasta/species`
  - uses `dna_index` folder if present, otherwise `dna`
  - downloads `*dna.toplevel*`
- fetches vcf data from `<release>/variation/vcf/<species>`
  - looks for `<species>.vcf.gz`
  - if not found, prompts user for a vcf to use (e.g. `<species>_somatic.vcf.gz`), or no file
  - .tbi index should be downloaded at the same time
- prepares data
  - checks that there is only 1 fasta
  - runs samtools faidx if .fai not present
  - runs `picard CreateSequenceDictionary` if .dict not present
  - checks that there is only 1 vcf
  - runs `gatk ValidateVariants`
  - .tbi index should have been downloaded alongside the vcf
- prepares metadata to push to Reporting-App
  - tool versions
  - Ensembl API data
    - assembly name
    - species
    - taxid
    - date added
    - chromosome number
    - genome size
    - analyses supported (qc, variant_calling, bcbio)
    - project whitelist
    - comments
    - prompts for user input if any data not found
- `--genome_version` to specify a genome version (defaults to genome in latest Ensembl release)
- `--no_upload` to turn off Reporting-App upload
- `--no_download` to turn off FTP download
- new config:
```yaml
reference_data:
    base_dir: path/to/reference_genomes
    picard: path/to/picard
    gatk: path/to/gatk
    samtools: path/to/samtools
```