### PR TITLE
Fix bug in archiving of runs during final data deletion

### DIFF
--- a/data_deletion/final_data.py
+++ b/data_deletion/final_data.py
@@ -60,7 +60,7 @@ class FinalDataDeleter(DeliveredDataDeleter):
     def _try_archive_run(self, run_id):
         # Ensure that all samples in that run have been fully deleted.
         run_elements = rest_communication.get_documents('run_elements', where={'run_id': run_id}, all_pages=True)
-        sample_ids = set(re[ELEMENT_SAMPLE_INTERNAL_ID] for re in run_elements)
+        sample_ids = set(re[ELEMENT_SAMPLE_INTERNAL_ID] for re in run_elements if re[ELEMENT_SAMPLE_INTERNAL_ID] != "Undetermined")
         samples = (rest_communication.get_document('samples', where={'sample_id': sample_id}) for sample_id in sample_ids)
         if all((sample['data_deleted'] == 'all' for sample in samples)):
             # remove all extra fastq files

--- a/data_deletion/final_data.py
+++ b/data_deletion/final_data.py
@@ -46,7 +46,8 @@ class FinalDataDeleter(DeliveredDataDeleter):
                 self.warning('Sample %s is not old enough: %s', final_sample.sample_id, final_sample.release_date)
                 ret = False
             if final_sample.sample_data.get('data_deleted') != 'on lustre':
-                self.warning('Sample %s is not marked as deleted from lustre', final_sample.sample_id, final_sample.release_date)
+                self.warning('Sample %s is not marked as deleted from lustre: %s',
+                             final_sample.sample_id, final_sample.sample_data.get('data_deleted'))
                 ret = False
         return ret
 
@@ -60,22 +61,26 @@ class FinalDataDeleter(DeliveredDataDeleter):
     def _try_archive_run(self, run_id):
         # Ensure that all samples in that run have been fully deleted.
         run_elements = rest_communication.get_documents('run_elements', where={'run_id': run_id}, all_pages=True)
-        sample_ids = set(re[ELEMENT_SAMPLE_INTERNAL_ID] for re in run_elements if re[ELEMENT_SAMPLE_INTERNAL_ID] != "Undetermined")
+        # Get all sample id involved in that run (removing the unassigned barcode for pooling runs)
+        sample_ids = set(re[ELEMENT_SAMPLE_INTERNAL_ID] for re in run_elements
+                         if re[ELEMENT_SAMPLE_INTERNAL_ID] != "Undetermined")
         samples = (rest_communication.get_document('samples', where={'sample_id': sample_id}) for sample_id in sample_ids)
         if all((sample['data_deleted'] == 'all' for sample in samples)):
             # remove all extra fastq files
             run_dir = os.path.join(self.fastq_dir, run_id)
-            files_to_remove = find_all_fastqs(run_dir)  # That should be the undetermined since all others were removed
-            files_to_remove.extend(self._find_files_with_suffix(run_dir, 'fastq_discarded.gz'))  # phix and adapters
-            files_to_remove.extend(self._find_files_with_suffix(run_dir, 'fastq.gz.original'))  # original when filtered
-            if files_to_remove:
-                deletable_data_dir = os.path.join(self.deletion_dir, run_id)
-                self._execute('mkdir -p ' + deletable_data_dir)
-                for f in files_to_remove:
-                    self._move_to_unique_file_name(f, deletable_data_dir)
+            # Do not archive runs that do not exist or have already been archived
+            if os.path.isdir(run_dir):
+                files_to_remove = find_all_fastqs(run_dir)  # That should be the undetermined since all others were removed
+                files_to_remove.extend(self._find_files_with_suffix(run_dir, 'fastq_discarded.gz'))  # phix and adapters
+                files_to_remove.extend(self._find_files_with_suffix(run_dir, 'fastq.gz.original'))  # original when filtered
+                if files_to_remove:
+                    deletable_data_dir = os.path.join(self.deletion_dir, run_id)
+                    self._execute('mkdir -p ' + deletable_data_dir)
+                    for f in files_to_remove:
+                        self._move_to_unique_file_name(f, deletable_data_dir)
 
-            self.debug('Archiving processed run: ' + run_id)
-            self._execute('mv %s %s' % (run_dir, os.path.join(self.run_archive_dir, run_id)))
+                self.debug('Archiving processed run: ' + run_id)
+                self._execute('mv %s %s' % (run_dir, os.path.join(self.run_archive_dir, run_id)))
 
     def _try_archive_project(self, project_id):
         # Ensure that all samples of that project have been fully deleted.
@@ -83,15 +88,17 @@ class FinalDataDeleter(DeliveredDataDeleter):
         if all((sample['data_deleted'] == 'all' for sample in samples)):
             # remove the extra vcf file from project process
             project_dir = os.path.join(self.projects_dir, project_id)
-            files_to_remove = self._find_files_with_suffix(project_dir, 'genotype_gvcfs.vcf.gz')
-            if files_to_remove:
-                deletable_data_dir = os.path.join(self.deletion_dir, project_id)
-                self._execute('mkdir -p ' + deletable_data_dir)
-                for f in files_to_remove:
-                    self._move_to_unique_file_name(f, deletable_data_dir)
+            # Do not archive project that have already been archived
+            if os.path.isdir(project_dir):
+                files_to_remove = self._find_files_with_suffix(project_dir, 'genotype_gvcfs.vcf.gz')
+                if files_to_remove:
+                    deletable_data_dir = os.path.join(self.deletion_dir, project_id)
+                    self._execute('mkdir -p ' + deletable_data_dir)
+                    for f in files_to_remove:
+                        self._move_to_unique_file_name(f, deletable_data_dir)
 
-            self.debug('Archiving processed project: ' + project_id)
-            self._execute('mv %s %s' % (project_dir, os.path.join(self.project_archive_dir, project_id)))
+                self.debug('Archiving processed project: ' + project_id)
+                self._execute('mv %s %s' % (project_dir, os.path.join(self.project_archive_dir, project_id)))
 
     def delete_data(self):
         deletable_samples = self.deletable_samples()

--- a/tests/test_data_deletion/test_final_deletion.py
+++ b/tests/test_data_deletion/test_final_deletion.py
@@ -16,6 +16,18 @@ run_elements2 = [
     {'run_id': 'another_run', 'project_id': 'another_project', 'sample_id': 'yet_another_sample', 'lane': 5}
 ]
 
+full_run = [
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample1', 'lane': 1},
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample2', 'lane': 2},
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample3', 'lane': 3},
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample4', 'lane': 4},
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample5', 'lane': 5},
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample6', 'lane': 6},
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample7', 'lane': 7},
+    {'run_id': 'a_run', 'project_id': 'a_project', 'sample_id': 'a_sample8', 'lane': 8},
+    {'run_id': 'a_run', 'project_id': 'default', 'sample_id': 'Undetermined', 'lane': 3},
+]
+
 sample1 = {
     'sample_id': 'a_sample',
     'release_dir': 'release_1',
@@ -161,7 +173,7 @@ class TestFinalDataDeleter(TestDeleter):
         mocked_archive_run.assert_any_call('a_run')
         mocked_archive_run.assert_any_call('another_run')
 
-    @patch('egcg_core.rest_communication.get_documents', return_value=run_elements1)
+    @patch('egcg_core.rest_communication.get_documents', return_value=full_run)
     @patch('egcg_core.rest_communication.get_document', return_value=sample1)
     def test_try_archive_run(self, mocked_get_doc, mocked_get_docs):
         assert os.path.exists(os.path.join(self.deleter.fastq_dir, 'a_run'))
@@ -169,6 +181,16 @@ class TestFinalDataDeleter(TestDeleter):
         self.deleter._try_archive_run('a_run')
         assert not os.path.exists(os.path.join(self.deleter.fastq_dir, 'a_run'))
         assert os.path.exists(os.path.join(self.deleter.run_archive_dir, 'a_run'))
+        mocked_get_docs.assert_called_once_with('run_elements', all_pages=True, where={'run_id': 'a_run'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample1'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample2'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample3'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample4'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample5'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample6'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample7'})
+        mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample8'})
+        # Undetermined is ignored
 
     @patch('egcg_core.rest_communication.get_documents', return_value=[sample1])
     def test_try_archive_project(self, mocked_get_docs):

--- a/tests/test_data_deletion/test_final_deletion.py
+++ b/tests/test_data_deletion/test_final_deletion.py
@@ -190,6 +190,7 @@ class TestFinalDataDeleter(TestDeleter):
         mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample6'})
         mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample7'})
         mocked_get_doc.assert_any_call('samples', where={'sample_id': 'a_sample8'})
+        assert mocked_get_doc.call_count == 8
         # Undetermined is ignored
 
     @patch('egcg_core.rest_communication.get_documents', return_value=[sample1])


### PR DESCRIPTION
filter out the "Undetermined" sample id before checking for data deletion status
also avoid archiving runs and project that are already archived or have never been created (for failed runs)
closes #91 