### PR TITLE
Stop listing samples as needing repeat if another processing run element exists

### DIFF
--- a/bin/report_runs.py
+++ b/bin/report_runs.py
@@ -141,7 +141,9 @@ def report_runs(run_ids, noemail=False):
                         round(mean_cov, 1), sdata['required_coverage']
                     )
                 # Checking for other run elements which are still pending
-                for sample_run_id in query_dict(sdata, 'run_elements') or []:
+                for sample_run_element in query_dict(sdata, 'run_elements') or []:
+                    # Removing the lane suffix from run element, to turn it into a run_id
+                    sample_run_id = sample_run_element[:sample_run_element.rfind("_")]
                     if query_dict(run_data(sample_run_id), 'aggregated.most_recent_proc.status') == 'processing':
                         reason += '. Another pending run element already exists'
                         break

--- a/bin/report_runs.py
+++ b/bin/report_runs.py
@@ -142,8 +142,11 @@ def report_runs(run_ids, noemail=False):
                     )
                 # Checking for other run elements which are still pending
                 for sample_run_element in query_dict(sdata, 'run_elements') or []:
-                    # Removing the lane suffix from run element, to turn it into a run_id
-                    sample_run_id = sample_run_element[:sample_run_element.rfind("_")]
+                    # Splitting the run element, and generating the run_id by concatenating the first four components
+                    # with an underscore
+                    sample_run_element_sections = sample_run_element.split('_')
+                    sample_run_id = sample_run_element_sections[0] + "_" + sample_run_element_sections[1] + "_" + \
+                        sample_run_element_sections[2] + "_" + sample_run_element_sections[3]
                     if query_dict(run_data(sample_run_id), 'aggregated.most_recent_proc.status') == 'processing':
                         reason += '. Another pending run element already exists'
                         break

--- a/bin/report_runs.py
+++ b/bin/report_runs.py
@@ -141,7 +141,7 @@ def report_runs(run_ids, noemail=False):
                         round(mean_cov, 1), sdata['required_coverage']
                     )
                 # Checking for other run elements which are still pending
-                for sample_run_id in query_dict(sdata, 'run_elements'):
+                for sample_run_id in query_dict(sdata, 'run_elements') or []:
                     if query_dict(run_data(sample_run_id), 'aggregated.most_recent_proc.status') == 'processing':
                         reason += '. Another pending run element already exists'
                         break

--- a/bin/report_runs.py
+++ b/bin/report_runs.py
@@ -145,8 +145,7 @@ def report_runs(run_ids, noemail=False):
                     # Splitting the run element, and generating the run_id by concatenating the first four components
                     # with an underscore
                     sample_run_element_sections = sample_run_element.split('_')
-                    sample_run_id = sample_run_element_sections[0] + "_" + sample_run_element_sections[1] + "_" + \
-                        sample_run_element_sections[2] + "_" + sample_run_element_sections[3]
+                    sample_run_id = '_'.join(sample_run_element.split('_')[:4])
                     if query_dict(run_data(sample_run_id), 'aggregated.most_recent_proc.status') == 'processing':
                         reason += '. Another pending run element already exists'
                         break

--- a/bin/report_runs.py
+++ b/bin/report_runs.py
@@ -144,7 +144,6 @@ def report_runs(run_ids, noemail=False):
                 for sample_run_element in query_dict(sdata, 'run_elements') or []:
                     # Splitting the run element, and generating the run_id by concatenating the first four components
                     # with an underscore
-                    sample_run_element_sections = sample_run_element.split('_')
                     sample_run_id = '_'.join(sample_run_element.split('_')[:4])
                     if query_dict(run_data(sample_run_id), 'aggregated.most_recent_proc.status') == 'processing':
                         reason += '. Another pending run element already exists'

--- a/bin/report_runs.py
+++ b/bin/report_runs.py
@@ -141,7 +141,7 @@ def report_runs(run_ids, noemail=False):
                         round(mean_cov, 1), sdata['required_coverage']
                     )
                 # Checking for other run elements which are still pending
-                for sample_run_id in sdata.query('run_elements'):
+                for sample_run_id in query_dict(sdata, 'run_elements'):
                     if query_dict(run_data(sample_run_id), 'aggregated.most_recent_proc.status') == 'processing':
                         reason += '. Another pending run element already exists'
                         break

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -150,7 +150,7 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
         email_template=report_runs.email_template_report,
         runs=[
             {'name': 'successful_run', 'failed_lanes': 0, 'details': []},
-            {'name': 'errored_id_id_lane', 'failed_lanes': 8, 'details': ['RunErrored']}
+            {'name': 'errored_run', 'failed_lanes': 8, 'details': ['RunErrored']}
         ]
     )
 

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -99,7 +99,7 @@ def test_get_run_success(mocked_logger):
 
 
 @patch('bin.report_runs.send_html_email')
-@patch('bin.report_runs.get_run_success', return_value={'name': 'successful_run', 'failed_lanes': 0, 'details': []})
+@patch('bin.report_runs.get_run_success', return_value={'name': 'run_id_id_lane', 'failed_lanes': 0, 'details': []})
 @patch('bin.report_runs.today', return_value='today')
 def test_report_runs(mocked_today, mocked_run_success, mocked_email):
     report_runs.cfg.content = {'run_report': {'email_notification': {}}}
@@ -149,8 +149,8 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
         subject='Run report today',
         email_template=report_runs.email_template_report,
         runs=[
-            {'name': 'successful_run', 'failed_lanes': 0, 'details': []},
-            {'name': 'errored_run', 'failed_lanes': 8, 'details': ['RunErrored']}
+            {'name': 'run_id_id_lane', 'failed_lanes': 0, 'details': []},
+            {'name': 'errored_id_id_lane', 'failed_lanes': 8, 'details': ['RunErrored']}
         ]
     )
 

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -104,25 +104,25 @@ def test_get_run_success(mocked_logger):
 def test_report_runs(mocked_today, mocked_run_success, mocked_email):
     report_runs.cfg.content = {'run_report': {'email_notification': {}}}
     report_runs.cache['run_status_data'] = {
-        'a_run': {
+        'run_id_id_lane': {
             'run_status': 'RunCompleted',
             'sample_ids': ['passing', 'no_data', 'poor_yield', 'poor_coverage', 'poor_yield_and_coverage']
         },
-        'errored_run': {
+        'errored_id_id_lane': {
             'run_status': 'RunErrored',
             'sample_ids': ['passing', 'no_data', 'poor_yield', 'poor_coverage', 'poor_yield_and_coverage']
         }
     }
 
     report_runs.cache['run_data'] = {
-        'a_run': {
+        'run_id_id_lane': {
             'aggregated': {
                 'most_recent_proc': {
                     'status': 'processing'
                 }
             }
         },
-        'errored_run': {
+        'errored_id_id_lane': {
             'aggregated': {
                 'most_recent_proc': {
                     'status': 'processing'
@@ -142,15 +142,15 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
     for s in report_runs.cache['sample_data'].values():
         s['required_yield'] = 2000000000
         s['required_coverage'] = 4
-        s['run_elements'] = ['a_run_laneno', 'errored_run_laneno']
+        s['run_elements'] = ['run_id_id_lane_barcode', 'errored_id_id_lane_barcode']
 
-    report_runs.report_runs(['a_run', 'errored_run'])
+    report_runs.report_runs(['run_id_id_lane', 'errored_id_id_lane'])
     mocked_email.assert_any_call(
         subject='Run report today',
         email_template=report_runs.email_template_report,
         runs=[
             {'name': 'successful_run', 'failed_lanes': 0, 'details': []},
-            {'name': 'errored_run', 'failed_lanes': 8, 'details': ['RunErrored']}
+            {'name': 'errored_id_id_lane', 'failed_lanes': 8, 'details': ['RunErrored']}
         ]
     )
 
@@ -163,7 +163,7 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
         subject='Sequencing repeats today',
         email_template=report_runs.email_template_repeats,
         runs=[
-            {'name': 'a_run', 'repeat_count': 2, 'repeats': exp_failing_samples},
-            {'name': 'errored_run', 'repeat_count': 2, 'repeats': exp_failing_samples}
+            {'name': 'run_id_id_lane', 'repeat_count': 2, 'repeats': exp_failing_samples},
+            {'name': 'errored_id_id_lane', 'repeat_count': 2, 'repeats': exp_failing_samples}
         ]
     )

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -149,8 +149,8 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
         subject='Run report today',
         email_template=report_runs.email_template_report,
         runs=[
+            {'name': 'errored_id_id_lane', 'failed_lanes': 8, 'details': ['RunErrored']},
             {'name': 'run_id_id_lane', 'failed_lanes': 0, 'details': []},
-            {'name': 'errored_id_id_lane', 'failed_lanes': 8, 'details': ['RunErrored']}
         ]
     )
 
@@ -163,7 +163,8 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
         subject='Sequencing repeats today',
         email_template=report_runs.email_template_repeats,
         runs=[
-            {'name': 'run_id_id_lane', 'repeat_count': 2, 'repeats': exp_failing_samples},
-            {'name': 'errored_id_id_lane', 'repeat_count': 2, 'repeats': exp_failing_samples}
+
+            {'name': 'errored_id_id_lane', 'repeat_count': 2, 'repeats': exp_failing_samples},
+            {'name': 'run_id_id_lane', 'repeat_count': 2, 'repeats': exp_failing_samples}
         ]
     )

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -142,7 +142,7 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
     for s in report_runs.cache['sample_data'].values():
         s['required_yield'] = 2000000000
         s['required_coverage'] = 4
-        s['run_elements'] = ['a_run', 'errored_run']
+        s['run_elements'] = ['a_run_laneno', 'errored_run_laneno']
 
     report_runs.report_runs(['a_run', 'errored_run'])
     mocked_email.assert_any_call(

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -114,6 +114,23 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
         }
     }
 
+    report_runs.cache['run_data'] = {
+        'a_run': {
+            'aggregated': {
+                'most_recent_proc': {
+                    'status': 'processing'
+                }
+            }
+        },
+        'errored_run': {
+            'aggregated': {
+                'most_recent_proc': {
+                    'status': 'processing'
+                }
+            }
+        }
+    }
+
     report_runs.cache['sample_data'] = {
         'passing': {'aggregated': {'clean_pc_q30': 75, 'clean_yield_in_gb': 2, 'from_run_elements': {'mean_coverage': 4}}},
         'no_data': {'aggregated': {}},
@@ -125,6 +142,7 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
     for s in report_runs.cache['sample_data'].values():
         s['required_yield'] = 2000000000
         s['required_coverage'] = 4
+        s['run_elements'] = ['a_run', 'errored_run']
 
     report_runs.report_runs(['a_run', 'errored_run'])
     mocked_email.assert_any_call(
@@ -137,8 +155,8 @@ def test_report_runs(mocked_today, mocked_run_success, mocked_email):
     )
 
     exp_failing_samples = [
-        {'id': 'no_data', 'reason': 'No data'},
-        {'id': 'poor_yield_and_coverage', 'reason': 'Not enough data: yield (1.0 < 2) and coverage (3 < 4)'}
+        {'id': 'no_data', 'reason': 'No data. Another pending run element already exists'},
+        {'id': 'poor_yield_and_coverage', 'reason': 'Not enough data: yield (1.0 < 2) and coverage (3 < 4). Another pending run element already exists'}
     ]
 
     mocked_email.assert_any_call(

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -37,6 +37,22 @@ def test_run_element_data(mocked_get_docs):
 
 
 @patch('egcg_core.rest_communication.get_document')
+def test_run_data(mocked_get_docs):
+    report_runs.cache['run_data'] = {}
+
+    mocked_get_docs.return_value = 'some data'
+    obs = report_runs.run_data('a_run')
+    assert obs == 'some data'
+    assert report_runs.cache['run_data'] == {'a_run': 'some data'}
+    mocked_get_docs.assert_called_with('runs', where={'run_id': 'a_run'})
+    assert mocked_get_docs.call_count == 1
+
+    obs = report_runs.run_data('a_run')
+    assert obs == 'some data'
+    assert mocked_get_docs.call_count == 1  # not called again
+
+
+@patch('egcg_core.rest_communication.get_document')
 def test_sample_data(mocked_get_docs):
     report_runs.cache['sample_data'] = {}
 


### PR DESCRIPTION
A new run_data function queries the API, caching associated data. 

If a sample has a pending run element and was selected for repeat, a warning is now appended.

closes #101 