### PR TITLE
Add species to Reporting app without adding a genome

### DIFF
--- a/bin/deliver_reviewed_data.py
+++ b/bin/deliver_reviewed_data.py
@@ -19,9 +19,8 @@ from egcg_core.notifications.email import send_html_email
 from egcg_core.util import find_files, find_fastqs, query_dict
 from pyclarity_lims.entities import Process
 
-from project_report.project_report_latex import ProjectReportLatex
-
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from project_report.project_report_latex import ProjectReportLatex
 from config import load_config
 
 hs_files = [

--- a/bin/recall_sample.py
+++ b/bin/recall_sample.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import argparse
 from shutil import disk_usage

--- a/bin/recall_sample.py
+++ b/bin/recall_sample.py
@@ -1,8 +1,11 @@
+import sys
 import argparse
 from shutil import disk_usage
 from egcg_core import rest_communication, archive_management as am
 from egcg_core.app_logging import logging_default
 from egcg_core.exceptions import EGCGError
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import cfg, load_config
 from data_deletion import ProcessedSample, get_file_list_size
 

--- a/bin/reference_data.py
+++ b/bin/reference_data.py
@@ -490,7 +490,7 @@ def upload_species_without_genome(species_name):
     )
     genome_data = rest_communication.get_document('genomes', where={'assembly_name': genome_version})
     if not genome_data:
-        logger.error('Genome %s does exist in the API. Add it separately with its own species', genome_version)
+        logger.error('Genome %s does not exist in the API. Add it separately with its own species', genome_version)
         return 1
     genome_size = float(int(genome_data.get('genome_size')) / 1000000)
     genome_size = input(

--- a/bin/reference_data.py
+++ b/bin/reference_data.py
@@ -469,6 +469,51 @@ class ManualDownload(Downloader):
             self.reference_variation = vcf
 
 
+def upload_species_without_genome(species_name):
+    """
+    This function only adds a new species without the need for a new genome.
+    An existing genome will be associated with the new species.
+    """
+    logger = logging_default.get_logger('SpeciesWithoutGenome')
+
+    scientific_name = ncbi.get_species_name(species_name)
+    if not scientific_name:
+        raise EGCGError('Species %s could not be resolved in NCBI please check the spelling.', species_name)
+
+    species = rest_communication.get_document('species', where={'name': scientific_name})
+    if species:
+        logger.error('Species %s already exist in the API', species_name)
+        return 1
+
+    genome_version = input(
+        "Enter genome version to use as the default genome for %s " % scientific_name
+    )
+    genome_data = rest_communication.get_document('genomes', where={'assembly_name': genome_version})
+    if not genome_data:
+        logger.error('Genome %s does exist in the API. Add it separately with its own species', genome_version)
+        return 1
+    genome_size = float(int(genome_data.get('genome_size')) / 1000000)
+    genome_size = input(
+        "Enter species genome size (in Mb) to use for yield calculation. (default: %.0f) " % genome_size
+    ) or genome_size
+
+    info = ncbi.fetch_from_cache(scientific_name)
+    if info:
+        q, taxid, scientific_name, common_name = info
+    else:
+        taxid, scientific_name, common_name = ncbi.fetch_from_eutils(scientific_name)
+
+    rest_communication.post_entry(
+        'species',
+        {
+            'name': scientific_name,
+            'default_version': genome_version,
+            'taxid': taxid,
+            'approximate_genome_size': float(genome_size)
+        }
+    )
+
+
 def main():
     a = argparse.ArgumentParser()
     a.add_argument(
@@ -478,6 +523,8 @@ def main():
     a.add_argument('--genome_version', default=None)
     a.add_argument('--no_upload', dest='upload', action='store_false', help='Turn off the metadata upload')
     a.add_argument('--manual', action='store_true', help='Run manual metadata upload only, even if present in Ensembl')
+    a.add_argument('--no_genome', action='store_true',
+                   help='Add a species without providing a genome. It will be linked to an existing genome.')
     a.add_argument('--debug', action='store_true', help='Show debug statement in the output')
     args = a.parse_args()
     load_config()
@@ -485,6 +532,8 @@ def main():
     logging_default.add_stdout_handler()
     if args.debug:
         logging_default.set_log_level(logging.DEBUG)
+    if args.no_genome:
+        upload_species_without_genome(args.species)
     if args.manual:
         d = ManualDownload(args.species, args.genome_version, args.upload)
         d.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-EGCG-Core>=0.8.1
+EGCG-Core>=0.11
 jinja2==2.8
 weasyprint==43
 cached-property>=1.3.0
 matplotlib==1.5.3
 pandas==0.19.2
 numpy==1.12.0
-pyclarity-lims==0.4.3
 pylatex==1.3.0


### PR DESCRIPTION
New option in reference data to upload a new species and linking it to an existing genome.
close #85 