### PR TITLE
Executor calls, GelDataDelivery fix

### DIFF
--- a/data_deletion/__init__.py
+++ b/data_deletion/__init__.py
@@ -69,9 +69,11 @@ class Deleter(app_logging.AppLogger):
 
     def _execute(self, cmd, cluster_execution=False):
         if not cluster_execution:
-            status = executor.local_execute(cmd).join()
+            e = executor.local_execute(cmd)
         else:
-            status = executor.cluster_execute(cmd, job_name='data_deletion', working_dir=self.work_dir).join()
+            e = executor.cluster_execute(cmd, job_name='data_deletion', cpus=1, mem=2, working_dir=self.work_dir)
+
+        status = e.join()
         if status:
             raise EGCGError('Command failed: ' + cmd)
 

--- a/tests/test_upload_to_gel/test_upload_to_gel.py
+++ b/tests/test_upload_to_gel/test_upload_to_gel.py
@@ -272,6 +272,9 @@ class TestGelDataDelivery(TestProjectManagement):
     def test_check_delivery_qc_failed(self):
         self._test_check_delivery('qc_failed', 'passed', 'failed')
 
+    def test_check_delivered(self):
+        self._test_check_delivery('delivered', None, None)
+
     def test_no_check_delivery(self):
         _id = self.gel_data_delivery.deliver_db.create_delivery('sample1', '123456789_ext_sample1')
         self.gel_data_delivery.deliver_db.set_upload_state(_id, 'passed')
@@ -284,8 +287,8 @@ class TestGelDataDelivery(TestProjectManagement):
             self.gel_data_delivery.deliver_db.cursor.execute('select * from delivery;')
             obs = self.gel_data_delivery.deliver_db.cursor.fetchone()
             mock_error.assert_called_with(
-                'Delivery %s sample %s qc check failed - was checked before on %s',
+                'Delivery %s sample %s: %s',
                 'ED00000001',
                 'sample1',
-                obs[9]
+                'QC check failed - was checked before on %s' % obs[9]
             )

--- a/upload_to_gel/deliver_data_to_gel.py
+++ b/upload_to_gel/deliver_data_to_gel.py
@@ -257,6 +257,7 @@ class GelDataDelivery(AppLogger):
         emit = self.error
         upload_state, md5_state, md5_confirm_date, qc_state, qc_confirm_date = info
         if upload_state == SUCCESS_KW and not all((md5_confirm_date, qc_confirm_date)):
+            emit = self.info
             sample = send_action_to_rest_api(action='get', delivery_id=self.delivery_id).json()
             if sample['state'] == 'delivered':
                 msg = 'Not yet checked'

--- a/upload_to_gel/deliver_data_to_gel.py
+++ b/upload_to_gel/deliver_data_to_gel.py
@@ -253,26 +253,33 @@ class GelDataDelivery(AppLogger):
             self.delivery_id,
             'upload_state', 'md5_state', 'md5_confirm_date', 'qc_state', 'qc_confirm_date'
         )
+        msg = ''
+        emit = self.error
         upload_state, md5_state, md5_confirm_date, qc_state, qc_confirm_date = info
         if upload_state == SUCCESS_KW and not all((md5_confirm_date, qc_confirm_date)):
             sample = send_action_to_rest_api(action='get', delivery_id=self.delivery_id).json()
-            param, status = sample['state'].split('_')  # md5_passed -> ('md5', 'passed')
-            if param == 'md5':
-                self.deliver_db.set_md5_state(self.delivery_id, status)
-            elif param == 'qc':
-                self.deliver_db.set_md5_state(self.delivery_id, SUCCESS_KW)  # if qc has passed, md5 must have passed
-                self.deliver_db.set_qc_state(self.delivery_id, status)
+            if sample['state'] == 'delivered':
+                msg = 'Not yet checked'
+            else:
+                param, status = sample['state'].split('_')  # md5_passed -> ('md5', 'passed')
+                if param == 'md5':
+                    self.deliver_db.set_md5_state(self.delivery_id, status)
+                elif param == 'qc':
+                    self.deliver_db.set_md5_state(self.delivery_id, SUCCESS_KW)  # if qc has passed, md5 must have passed
+                    self.deliver_db.set_qc_state(self.delivery_id, status)
 
-            self.info('Delivery %s sample %s %s check: %s', self.delivery_id, self.sample_id, param, status)
+                msg = '%s check %s' % (param, status)
 
         elif not upload_state:
-            self.error('Delivery %s sample %s: Has not been uploaded', self.delivery_id, self.sample_id)
+            msg = 'Has not been uploaded'
         elif upload_state == FAILURE_KW:
-            self.error('Delivery %s sample %s: Upload failed', self.delivery_id, self.sample_id)
+            msg = 'Upload failed'
         elif qc_state:
-            self.error('Delivery %s sample %s qc check failed - was checked before on %s', self.delivery_id, self.sample_id, qc_confirm_date)
+            msg = 'QC check failed - was checked before on %s' % qc_confirm_date
         elif md5_state:
-            self.error('Delivery %s sample %s md5 check failed - was checked before on %s', self.delivery_id, self.sample_id, md5_confirm_date)
+            msg = 'MD5 check failed - was checked before on %s' % md5_confirm_date
+
+        emit('Delivery %s sample %s: %s', self.delivery_id, self.sample_id, msg)
 
 
 def check_all_deliveries():


### PR DESCRIPTION
- Ensures all cluster_execute calls declare `cpus` and `mem` - closes #100 
- Adds support for status 'delivered' to GelDataDelivery.check_delivery_data - fixes #69